### PR TITLE
Update variational_inference.py

### DIFF
--- a/gpjax/variational_inference.py
+++ b/gpjax/variational_inference.py
@@ -142,7 +142,7 @@ class StochasticVI(AbstractVariationalInference):
         log_prob = vmap(lambda f, y: link_function(params["likelihood"], f).log_prob(y))
 
         # ≈ ∫[log(p(y|f(x))) q(f(x))] df(x)
-        expectation = gauss_hermite_quadrature(log_prob, mean, variance, y=y)
+        expectation = gauss_hermite_quadrature(log_prob, mean, jnp.sqrt(variance), y=y)
 
         return expectation
 


### PR DESCRIPTION
The quadrature function takes in standard deviation, not variance. This is a one line bug fix.