### PR TITLE
Changed dev install instructions to get all required dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Clone a copy of the repository to your local machine and run the setup configura
 ```bash
 git clone https://github.com/JaxGaussianProcesses/GPJax.git
 cd GPJax
-python setup.py develop
+pip install -e .[dev]
 ```
 
 > **Note**


### PR DESCRIPTION
Changed recommended install to get all required dependencies. Before we didn't install all the required packages for doing dev work, e.g. "pytest". This was confusing as the command below the one I changed involved pytest


## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We install GPJax but **not** the packages required for dev work (e.g. pytest, flake8,....)
Issue Number: N/A

## What is the new behavior?


We install GPJax but **and** the packages required for dev work (e.g. pytest, flake8,....)

