### PR TITLE
Correct key handling in examples

### DIFF
--- a/examples/classification.pct.py
+++ b/examples/classification.pct.py
@@ -50,8 +50,9 @@ key = jr.PRNGKey(123)
 # We store our data $\mathcal{D}$ as a GPJax `Dataset` and create test inputs for later.
 
 # %%
-x = jnp.sort(jr.uniform(key, shape=(100, 1), minval=-1.0, maxval=1.0), axis=0)
-y = 0.5 * jnp.sign(jnp.cos(3 * x + jr.normal(key, shape=x.shape) * 0.05)) + 0.5
+key, subkey = jr.split(key)
+x = jr.uniform(key, shape=(100, 1), minval=-1.0, maxval=1.0)
+y = 0.5 * jnp.sign(jnp.cos(3 * x + jr.normal(subkey, shape=x.shape) * 0.05)) + 0.5
 
 D = Dataset(X=x, y=y)
 

--- a/examples/collapsed_vi.pct.py
+++ b/examples/collapsed_vi.pct.py
@@ -48,10 +48,11 @@ key = jr.PRNGKey(123)
 n = 2500
 noise = 0.5
 
-x = jr.uniform(key=key, minval=-3.0, maxval=3.0, shape=(n,)).sort().reshape(-1, 1)
+key, subkey = jr.split(key)
+x = jr.uniform(key=key, minval=-3.0, maxval=3.0, shape=(n,)).reshape(-1, 1)
 f = lambda x: jnp.sin(2 * x) + x * jnp.cos(5 * x)
 signal = f(x)
-y = signal + jr.normal(key, shape=signal.shape) * noise
+y = signal + jr.normal(subkey, shape=signal.shape) * noise
 
 D = Dataset(X=x, y=y)
 

--- a/examples/natgrads.pct.py
+++ b/examples/natgrads.pct.py
@@ -49,10 +49,11 @@ key = jr.PRNGKey(123)
 n = 5000
 noise = 0.2
 
-x = jr.uniform(key=key, minval=-5.0, maxval=5.0, shape=(n,)).sort().reshape(-1, 1)
+key, subkey = jr.split(key)
+x = jr.uniform(key=key, minval=-5.0, maxval=5.0, shape=(n,)).reshape(-1, 1)
 f = lambda x: jnp.sin(4 * x) + jnp.cos(2 * x)
 signal = f(x)
-y = signal + jr.normal(key, shape=signal.shape) * noise
+y = signal + jr.normal(subkey, shape=signal.shape) * noise
 
 D = Dataset(X=x, y=y)
 xtest = jnp.linspace(-5.5, 5.5, 500).reshape(-1, 1)

--- a/examples/regression.pct.py
+++ b/examples/regression.pct.py
@@ -50,10 +50,11 @@ key = jr.PRNGKey(123)
 n = 100
 noise = 0.3
 
-x = jr.uniform(key=key, minval=-3.0, maxval=3.0, shape=(n,)).sort().reshape(-1, 1)
+key, subkey = jr.split(key)
+x = jr.uniform(key=key, minval=-3.0, maxval=3.0, shape=(n,)).reshape(-1, 1)
 f = lambda x: jnp.sin(4 * x) + jnp.cos(2 * x)
 signal = f(x)
-y = signal + jr.normal(key, shape=signal.shape) * noise
+y = signal + jr.normal(subkey, shape=signal.shape) * noise
 
 D = Dataset(X=x, y=y)
 

--- a/examples/tfp_integration.pct.py
+++ b/examples/tfp_integration.pct.py
@@ -49,9 +49,10 @@ key = jr.PRNGKey(123)
 n = 100
 noise = 0.1
 
-x = jnp.sort(jr.uniform(key, minval=-5.0, maxval=5.0, shape=(n, 1)), axis=0)
+key, subkey = jr.split(key)
+x = jr.uniform(key, minval=-5.0, maxval=5.0, shape=(n, 1))
 f = lambda x: jnp.sin(jnp.pi * x) / (jnp.pi * x)
-y = f(x) + jr.normal(key, shape=x.shape) * noise
+y = f(x) + jr.normal(subkey, shape=x.shape) * noise
 
 fig, ax = plt.subplots(figsize=(12, 6))
 ax.plot(x, f(x), label="Latent fn")

--- a/examples/uncollapsed_vi.pct.py
+++ b/examples/uncollapsed_vi.pct.py
@@ -54,10 +54,11 @@ key = jr.PRNGKey(123)
 n = 5000
 noise = 0.2
 
-x = jr.uniform(key=key, minval=-5.0, maxval=5.0, shape=(n,)).sort().reshape(-1, 1)
+key, subkey = jr.split(key)
+x = jr.uniform(key=key, minval=-5.0, maxval=5.0, shape=(n,)).reshape(-1, 1)
 f = lambda x: jnp.sin(4 * x) + jnp.cos(2 * x)
 signal = f(x)
-y = signal + jr.normal(key, shape=signal.shape) * noise
+y = signal + jr.normal(subkey, shape=signal.shape) * noise
 
 D = Dataset(X=x, y=y)
 


### PR DESCRIPTION


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In some of the examples, the same PRNGKey is used to generate both x and the noise in y, and x is sorted to avoid the correlation resulting by using the same key. This could be somewhat confusing for new users (myself included).

## What is the new behavior?

We simply split the key and use two separate keys to generate x and the noise in y. 
