### PR TITLE
Allow initializing parameters of sum of kernels

### DIFF
--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -93,7 +93,11 @@ def initialise(model, key: KeyArray = None, **kwargs) -> ParameterState:
     if kwargs:
         _validate_kwargs(kwargs, params)
         for k, v in kwargs.items():
-            params[k] = merge_dictionaries(params[k], v)
+            if isinstance(params[k], dict):
+                params[k] = merge_dictionaries(params[k], v)
+            else:
+                for i in range(len(params[k])):
+                    params[k][i] = merge_dictionaries(params[k][i], v[i])
 
     bijectors = build_bijectors(params)
     trainables = build_trainables(params)


### PR DESCRIPTION
When using as kernel a sum of kernels, e.g., `jk.Periodic() + jk.White()`, then their parameters are stored as a list of dictionaries.
Currently, attempting to initialize their parameters throws an error.
This change fixes this.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, attempting to initialize the parameters of one of the kernels fails with an error:

```
AttributeError: 'list' object has no attribute 'items'
```

Issue Number: N/A

## What is the new behavior?

With this change, it is possible to update the parameters of a sum of kernels. For the above example, one can pass the argument `kernel=[{"period": jnp.array([10.0])}, {}]` to `gpx.initialise` to set the period of the periodic kernel to `10`.