### PR TITLE
Tidy up RFF and extra tests/formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     rev: 23.3.0
     hooks:
     - id: black
-      language_version: python3.8
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,9 +59,14 @@ project = "GPJax"
 copyright = "2021, Thomas Pinder"
 author = "Thomas Pinder"
 
+from os.path import (
+    dirname,
+    join,
+    pardir,
+)
+
 # The full version, including alpha/beta/rc tags
 import sys
-from os.path import dirname, join, pardir
 
 sys.path.insert(0, join(dirname(__file__), pardir))
 

--- a/docs/conf_sphinx_patch.py
+++ b/docs/conf_sphinx_patch.py
@@ -1,6 +1,12 @@
 # This file is credited to the Flax authors.
 
-from typing import Any, Dict, List, Set, Tuple
+from typing import (
+    Any,
+    Dict,
+    List,
+    Set,
+    Tuple,
+)
 
 import sphinx.ext.autodoc
 import sphinx.ext.autosummary.generate as ag

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -23,7 +23,7 @@ from gpjax.kernels import *
 from gpjax.likelihoods import (
     Bernoulli,
     Gaussian,
-    Poisson
+    Poisson,
 )
 from gpjax.mean_functions import (
     Constant,

--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 from beartype.typing import (
     Any,
     Callable,
-    Dict,
     Optional,
 )
 import jax.numpy as jnp
@@ -269,17 +268,18 @@ class Prior(AbstractPrior):
             FunctionalSample: A function representing an approximate sample from the Gaussian
             process prior.
         """
-        if (not isinstance(num_features, int)) or num_features <= 0:
-            raise ValueError("num_features must be a positive integer")
+
         if (not isinstance(num_samples, int)) or num_samples <= 0:
             raise ValueError("num_samples must be a positive integer")
 
-        approximate_kernel = RFF(base_kernel=self.kernel, num_basis_fns=num_features)
+        # sample fourier features
+        fourier_feature_fn = _build_fourier_features_fn(self, num_features, key)
+
+        # sample fourier weights
         feature_weights = normal(key, [num_samples, 2 * num_features])  # [B, L]
 
         def sample_fn(test_inputs: Float[Array, "N D"]) -> Float[Array, "N B"]:
-            feature_evals = approximate_kernel.compute_features(x=test_inputs)
-            feature_evals *= jnp.sqrt(self.kernel.variance / num_features)
+            feature_evals = fourier_feature_fn(test_inputs)  # [N, L]
             evaluated_sample = jnp.inner(feature_evals, feature_weights)  # [N, B]
             return self.mean_function(test_inputs) + evaluated_sample
 
@@ -501,24 +501,13 @@ class ConjugatePosterior(AbstractPosterior):
             FunctionalSample: A function representing an approximate sample from the Gaussian
             process prior.
         """
-        if (not isinstance(num_features, int)) or num_features <= 0:
-            raise ValueError("num_features must be a positive integer")
         if (not isinstance(num_samples, int)) or num_samples <= 0:
             raise ValueError("num_samples must be a positive integer")
 
-        # Approximate kernel with feature decomposition
-        approximate_kernel = RFF(
-            base_kernel=self.prior.kernel, num_basis_fns=num_features
-        )
+        # sample fourier features
+        fourier_feature_fn = _build_fourier_features_fn(self.prior, num_features, key)
 
-        def eval_fourier_features(
-            test_inputs: Float[Array, "N D"]
-        ) -> Float[Array, "N L"]:
-            Phi = approximate_kernel.compute_features(x=test_inputs)
-            Phi *= jnp.sqrt(self.prior.kernel.variance / num_features)
-            return Phi
-
-        # sample weights for Fourier features
+        # sample fourier weights
         fourier_weights = normal(key, [num_samples, 2 * num_features])  # [B, L]
 
         # sample weights v for canonical features
@@ -531,13 +520,13 @@ class ConjugatePosterior(AbstractPosterior):
             key, [train_data.n, num_samples]
         )  #  [N, B]
         y = train_data.y - self.prior.mean_function(train_data.X)  # account for mean
-        Phi = eval_fourier_features(train_data.X)
+        Phi = fourier_feature_fn(train_data.X)
         canonical_weights = Sigma.solve(
             y + eps - jnp.inner(Phi, fourier_weights)
         )  #  [N, B]
 
         def sample_fn(test_inputs: Float[Array, "n D"]) -> Float[Array, "n B"]:
-            fourier_features = eval_fourier_features(test_inputs)
+            fourier_features = fourier_feature_fn(test_inputs)  # [n, L]
             weight_space_contribution = jnp.inner(
                 fourier_features, fourier_weights
             )  # [n, B]
@@ -634,6 +623,9 @@ class NonConjugatePosterior(AbstractPosterior):
         return GaussianDistribution(jnp.atleast_1d(mean.squeeze()), covariance)
 
 
+#######################
+# Utils
+#######################
 def construct_posterior(
     prior: Prior, likelihood: AbstractLikelihood
 ) -> AbstractPosterior:
@@ -656,6 +648,37 @@ def construct_posterior(
         return ConjugatePosterior(prior=prior, likelihood=likelihood)
 
     return NonConjugatePosterior(prior=prior, likelihood=likelihood)
+
+
+def _build_fourier_features_fn(
+    prior: Prior, num_features: int, key: KeyArray
+) -> Callable[[Float[Array, "N D"]], Float[Array, "N L"]]:
+    """Return a function that evaluates features sampled from the Fourier feature
+    decomposition of the prior's kernel.
+
+    Args:
+        prior (Prior): The Prior distribution.
+        num_features (int): The number of feature functions to be sampled.
+        key (KeyArray): The random seed used.
+
+    Returns
+    -------
+        Callable: A callable function evaluation the sampled feature functions.
+    """
+    if (not isinstance(num_features, int)) or num_features <= 0:
+        raise ValueError("num_features must be a positive integer")
+
+    # Approximate kernel with feature decomposition
+    approximate_kernel = RFF(
+        base_kernel=prior.kernel, num_basis_fns=num_features, key=key
+    )
+
+    def eval_fourier_features(test_inputs: Float[Array, "N D"]) -> Float[Array, "N L"]:
+        Phi = approximate_kernel.compute_features(x=test_inputs)
+        Phi *= jnp.sqrt(prior.kernel.variance / num_features)
+        return Phi
+
+    return eval_fourier_features
 
 
 __all__ = [

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -200,7 +200,6 @@ class TestPoisson(BaseTestLikelihood):
     def _test_call_check(
         likelihood: AbstractLikelihood, latent_mean, latent_cov, latent_dist
     ):
-
         # Test call method.
         pred_dist = likelihood(latent_dist)
 


### PR DESCRIPTION
Based on potential worry from @frazane, I have changed the unit tests to be for a 2d dataset with ARD (i.e. different lengthscales). 

I also fixed a small bug that was added when changing the backend (@thomaspinder ;)) which meant that we never controlled the seed that set the random fourier features. Previously, I was using a `.init_params` but this wasn't updated properly.

While I was at it, I also tidied my code slightly to reuse RFF functionality between the prior and posterior samplers.


There was a bit of extra formatting fixing that went on as well. Not sure why???


