### PR TITLE
Add static field to base, update tests to run on 3.11, fix 3.11 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Select the Python versions to test against
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: true
     steps:
       - name: Check out the code

--- a/examples/deep_kernels.pct.py
+++ b/examples/deep_kernels.pct.py
@@ -22,7 +22,7 @@ from flax import linen as nn
 from jax.config import config
 from jaxtyping import Array, Float
 from scipy.signal import sawtooth
-from simple_pytree import static_field
+from gpjax.base import static_field
 
 from jaxtyping import install_import_hook
 

--- a/examples/kernels.pct.py
+++ b/examples/kernels.pct.py
@@ -17,7 +17,7 @@ import tensorflow_probability.substrates.jax as tfp
 from jax import jit
 from jax.config import config
 from jaxtyping import Array, Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 
 from jaxtyping import install_import_hook
 

--- a/gpjax/base/__init__.py
+++ b/gpjax/base/__init__.py
@@ -20,6 +20,7 @@ from gpjax.base.module import (
     meta_flatten,
     meta_leaves,
     meta_map,
+    static_field,
     save_tree,
 )
 from gpjax.base.param import param_field
@@ -31,6 +32,7 @@ __all__ = [
     "meta_map",
     "meta",
     "param_field",
+    "static_field",
     "save_tree",
     "load_tree",
 ]

--- a/gpjax/base/module.py
+++ b/gpjax/base/module.py
@@ -33,6 +33,7 @@ from beartype.typing import (
     Tuple,
     TypeVar,
     Union,
+    Mapping,
 )
 import jax
 from jax import lax
@@ -48,11 +49,39 @@ from orbax.checkpoint import (
 )
 from simple_pytree import (
     Pytree,
-    static_field,
 )
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 Self = TypeVar("Self")
+
+
+def static_field(
+    default: Any = dataclasses.MISSING,
+    *,
+    default_factory: Any = dataclasses.MISSING,
+    init: bool = True,
+    repr: bool = True,
+    hash: Optional[bool] = None,
+    compare: bool = True,
+    metadata: Optional[Mapping[str, Any]] = None,
+):
+
+    metadata = {} if metadata is None else dict(metadata)
+
+    if "pytree_node" in metadata:
+        raise ValueError("Cannot use metadata with `pytree_node` already set.")
+
+    metadata["pytree_node"] = False
+
+    return dataclasses.field(
+        default=default,
+        default_factory=default_factory,
+        init=init,
+        repr=repr,
+        hash=hash,
+        compare=compare,
+        metadata=metadata,
+    )
 
 
 class Module(Pytree):

--- a/gpjax/base/module.py
+++ b/gpjax/base/module.py
@@ -73,14 +73,19 @@ def static_field(
 
     metadata["pytree_node"] = False
 
+    if default is not dataclasses.MISSING and default_factory is not dataclasses.MISSING:
+        raise ValueError("Cannot specify both default and default_factory.")
+    
+    if default is not dataclasses.MISSING:
+        default_factory = lambda: default
+
     return dataclasses.field(
-        default=default,
-        default_factory=default_factory,
-        init=init,
-        repr=repr,
-        hash=hash,
-        compare=compare,
-        metadata=metadata,
+    default_factory=default_factory,
+    init=init,
+    repr=repr,
+    hash=hash,
+    compare=compare,
+    metadata=metadata,
     )
 
 

--- a/gpjax/base/module.py
+++ b/gpjax/base/module.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 
-__all__ = ["Module", "meta_leaves", "meta_flatten", "meta_map", "meta"]
+__all__ = ["Module", "meta_leaves", "meta_flatten", "meta_map", "meta", "static_field"]
 
 from copy import (
     copy,

--- a/gpjax/base/param.py
+++ b/gpjax/base/param.py
@@ -53,12 +53,17 @@ def param_field(
     metadata["trainable"] = trainable
     metadata["pytree_node"] = True
 
+    if default is not dataclasses.MISSING and default_factory is not dataclasses.MISSING:
+        raise ValueError("Cannot specify both default and default_factory.")
+    
+    if default is not dataclasses.MISSING:
+        default_factory = lambda: default
+
     return dataclasses.field(
-        default=default,
-        default_factory=default_factory,
-        init=init,
-        repr=repr,
-        hash=hash,
-        compare=compare,
-        metadata=metadata,
+    default_factory=default_factory,
+    init=init,
+    repr=repr,
+    hash=hash,
+    compare=compare,
+    metadata=metadata,
     )

--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -30,7 +30,7 @@ from jaxtyping import (
     Float,
     Num,
 )
-from simple_pytree import static_field
+from gpjax.base import static_field
 
 from gpjax.base import (
     Module,

--- a/gpjax/kernels/approximations/rff.py
+++ b/gpjax/kernels/approximations/rff.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from jax.random import PRNGKey
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from gpjax.base import param_field

--- a/gpjax/kernels/base.py
+++ b/gpjax/kernels/base.py
@@ -34,7 +34,7 @@ from jaxtyping import (
     Float,
     Num,
 )
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from gpjax.base import (

--- a/gpjax/kernels/non_euclidean/graph.py
+++ b/gpjax/kernels/non_euclidean/graph.py
@@ -22,7 +22,7 @@ from jaxtyping import (
     Int,
     Num,
 )
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax as tfp
 
 from gpjax.base import param_field

--- a/gpjax/kernels/nonstationary/arccosine.py
+++ b/gpjax/kernels/nonstationary/arccosine.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from beartype.typing import Union
 import jax.numpy as jnp
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from gpjax.base import param_field

--- a/gpjax/kernels/nonstationary/polynomial.py
+++ b/gpjax/kernels/nonstationary/polynomial.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 
 import jax.numpy as jnp
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from gpjax.base import param_field

--- a/gpjax/kernels/stationary/white.py
+++ b/gpjax/kernels/stationary/white.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 
 import jax.numpy as jnp
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax.bijectors as tfb
 import tensorflow_probability.substrates.jax.distributions as tfd
 

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -23,7 +23,7 @@ from beartype.typing import (
 import jax.numpy as jnp
 import jax.scipy as jsp
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax as tfp
 
 from gpjax.base import (

--- a/gpjax/linops/constant_diagonal_linear_operator.py
+++ b/gpjax/linops/constant_diagonal_linear_operator.py
@@ -22,7 +22,7 @@ from beartype.typing import (
 )
 import jax.numpy as jnp
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 
 from gpjax.linops.diagonal_linear_operator import DiagonalLinearOperator
 from gpjax.linops.linear_operator import LinearOperator

--- a/gpjax/mean_functions.py
+++ b/gpjax/mean_functions.py
@@ -28,7 +28,7 @@ from jaxtyping import (
     Float,
     Num,
 )
-from simple_pytree import static_field
+from gpjax.base import static_field
 
 from gpjax.base import (
     Module,

--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import jax.scipy as jsp
 import jax.tree_util as jtu
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax as tfp
 
 from gpjax.base import Module

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -20,7 +20,7 @@ from beartype.typing import Any
 import jax.numpy as jnp
 import jax.scipy as jsp
 from jaxtyping import Float
-from simple_pytree import static_field
+from gpjax.base import static_field
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from gpjax.base import (

--- a/tests/test_base/test_module.py
+++ b/tests/test_base/test_module.py
@@ -32,13 +32,13 @@ import jax.tree_util as jtu
 import pytest
 from simple_pytree import (
     Pytree,
-    static_field,
 )
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from gpjax.base.module import (
     Module,
     meta,
+    static_field,
 )
 from gpjax.base.param import param_field
 

--- a/tests/test_kernels/test_base.py
+++ b/tests/test_kernels/test_base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from jax.config import config
 import jax.numpy as jnp
@@ -55,7 +55,7 @@ def test_abstract_kernel():
     # Create a dummy kernel class with __call__ implemented:
     @dataclass
     class DummyKernel(AbstractKernel):
-        test_a: Float[Array, "1"] = jnp.array([1.0])
+        test_a: Float[Array, "1"] = field(default_factory = lambda: jnp.array([1.0]))
         test_b: Float[Array, "1"] = param_field(
             jnp.array([2.0]), bijector=tfb.Softplus()
         )

--- a/tests/test_linops/test_linear_operator.py
+++ b/tests/test_linops/test_linear_operator.py
@@ -21,7 +21,7 @@ from dataclasses import (
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import pytest
-from simple_pytree import static_field
+from gpjax.base import static_field
 
 from gpjax.linops.linear_operator import LinearOperator
 


### PR DESCRIPTION
This PR comprises the following changes:

- (1) Add `static_field` to base, and use this in the testing.

- (2) Limit `simple_pytree` imports to 3 places (and the tests only):
    - (a)`gpjax.base`
    - (b)`gpjax.linops.linear_operator` (We should update this to a module in future).
    - (c)`gpjax.dataset` (We should update this to a module in future).

There should be no other imports. 

- Will need to remove `simple_pytree` imports from the `docs_update` branch in a separate PR.
- Perhaps ought to consider (in a future PR), only using `Module` and limiting `simple_pytree` import to `gpjax.base`.


This PR  also fixes compatibility issues with Python 3.11, that requires dataclass fields to be hashable (while jax.Arrays are not...).