### PR TITLE
Add isotropy test

### DIFF
--- a/tests/test_kernels/test_stationary.py
+++ b/tests/test_kernels/test_stationary.py
@@ -162,6 +162,13 @@ class BaseTestKernel:
             assert sdensity.loc == jnp.array(0.0)
             assert sdensity.scale == jnp.array(1.0)
 
+    @pytest.mark.parametrize("dim", [1, 3], ids=lambda x: f"dim={x}")
+    def test_isotropic(self, dim: int):
+        # Initialise kernel
+        kernel: AbstractKernel = self.kernel(active_dims=list(range(dim)))
+        if self.kernel not in [White]:
+            assert kernel.lengthscale.shape == ()
+
 
 def prod(inp):
     return [dict(zip(inp.keys(), values)) for values in product(*inp.values())]


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [X] I've added tests for new code.
- [X] I've added docstrings for the new code.

## Description

In GPJax versions <0.6, we have a bug that prevented users defining an isotropic kernel when their data was greater than a single dimension. This issue was inadvertently fixed in the v0.6 release. This PR simply adds a test to make sure an isotropic kernel can be specified.

Issue Number: #237 
