### PR TITLE
Bugfix powered_exponential.py

### DIFF
--- a/gpjax/kernels/stationary/powered_exponential.py
+++ b/gpjax/kernels/stationary/powered_exponential.py
@@ -31,9 +31,11 @@ from gpjax.typing import (
 
 @dataclass
 class PoweredExponential(AbstractKernel):
-    r"""The powered exponential family of kernels.
+    r"""The powered exponential family of kernels. This also equivalent to the symmetric generalized normal distribution.
 
-    Key reference is Diggle and Ribeiro (2007) - "Model-based Geostatistics".
+    See Diggle and Ribeiro (2007) - "Model-based Geostatistics".
+    and   
+    https://en.wikipedia.org/wiki/Generalized_normal_distribution#Symmetric_version
 
     """
 
@@ -41,7 +43,7 @@ class PoweredExponential(AbstractKernel):
         jnp.array(1.0), bijector=tfb.Softplus()
     )
     variance: ScalarFloat = param_field(jnp.array(1.0), bijector=tfb.Softplus())
-    power: ScalarFloat = param_field(jnp.array(1.0))
+    power: ScalarFloat = param_field(jnp.array(1.0), bijector=tfb.Sigmoid())
     name: str = "Powered Exponential"
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,8 @@ plugins:
   - mkdocs-jupyter:
       execute: false
       allow_errors: false
+      include: ["examples/*.py"]
+      ignore: ["examples/utils.py", "_statch/*.py", "scripts/*.py"]
     # binder: true
     # binder_service_name: "gh"
 #     binder_branch: "main"

--- a/tests/test_kernels/test_stationary.py
+++ b/tests/test_kernels/test_stationary.py
@@ -108,7 +108,7 @@ class BaseTestKernel:
             if field in ["variance", "lengthscale", "period", "alpha"]:
                 assert isinstance(meta[field]["bijector"], tfb.Softplus)
             if field in ["power"]:
-                assert isinstance(meta[field]["bijector"], tfb.Identity)
+                assert isinstance(meta[field]["bijector"], tfb.Sigmoid)
 
             # Trainability state
             assert meta[field]["trainable"] is True
@@ -225,7 +225,7 @@ class TestPeriodic(BaseTestKernel):
 class TestPoweredExponential(BaseTestKernel):
     kernel = PoweredExponential
     fields = prod(
-        {"lengthscale": [0.1, 1.0], "variance": [0.1, 1.0], "power": [0.1, 2.0]}
+        {"lengthscale": [0.1, 1.0], "variance": [0.1, 1.0], "power": [0.1, 0.9]}
     )
     params = {"test_initialization": fields}
     default_compute_engine = DenseKernelComputation


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Based on the equivalence of this kernel with symmetric generalized gaussian densities (up to a difference in the power parametrization) and according to https://en.wikipedia.org/wiki/Generalized_normal_distribution#Connection_to_Positive-Definite_Functions the power parameter has to be in the interval (0, 1] for the kernel to be positive semidefinite. Adding a Sigmoid constraint to enforce that.

Issue Number: N/A
