### PR TITLE
Static typing fixes

### DIFF
--- a/gpjax/fit.py
+++ b/gpjax/fit.py
@@ -19,6 +19,7 @@ from beartype.typing import (
     Callable,
     Optional,
     Tuple,
+    TypeVar,
     Union,
 )
 import jax
@@ -36,11 +37,13 @@ from gpjax.typing import (
     ScalarFloat,
 )
 
+ModuleModel = TypeVar("ModuleModel", bound=Module)
+
 
 def fit(  # noqa: PLR0913
     *,
-    model: Module,
-    objective: Union[AbstractObjective, Callable[[Module, Dataset], ScalarFloat]],
+    model: ModuleModel,
+    objective: Union[AbstractObjective, Callable[[ModuleModel, Dataset], ScalarFloat]],
     train_data: Dataset,
     optim: ox.GradientTransformation,
     key: KeyArray,
@@ -50,7 +53,7 @@ def fit(  # noqa: PLR0913
     verbose: Optional[bool] = True,
     unroll: Optional[int] = 1,
     safe: Optional[bool] = True,
-) -> Tuple[Module, Array]:
+) -> Tuple[ModuleModel, Array]:
     r"""Train a Module model with respect to a supplied Objective function.
     Optimisers used here should originate from Optax.
 

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -207,8 +207,11 @@ def inv_probit(x: Float[Array, " *N"]) -> Float[Array, " *N"]:
     return 0.5 * (1.0 + jsp.special.erf(x / jnp.sqrt(2.0))) * (1 - 2 * jitter) + jitter
 
 
+NonGaussianLikelihood = Union[Poisson, Bernoulli]
+
 __all__ = [
     "AbstractLikelihood",
+    "NonGaussianLikelihood",
     "Gaussian",
     "Bernoulli",
     "Poisson",

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -21,7 +21,10 @@ except ImportError:
     ValidationErrors = ValueError
 
 from dataclasses import is_dataclass
-from typing import Callable
+from typing import (
+    Callable,
+    Type,
+)
 
 from jax.config import config
 import jax.numpy as jnp
@@ -214,7 +217,7 @@ def test_nonconjugate_posterior(
 @pytest.mark.parametrize("kernel", [RBF(), Matern52()])
 @pytest.mark.parametrize("mean_function", [Zero(), Constant()])
 def test_posterior_construct(
-    likelihood: AbstractLikelihood,
+    likelihood: Type[AbstractLikelihood],
     num_datapoints: int,
     mean_function: AbstractMeanFunction,
     kernel: AbstractKernel,


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

I added two small improvements to the static typing which will make coding with GPJax a bit easier, especially in fully featured IDEs.

- `construct_posterior` and `__mul__` are overloaded such that the correct posterior (abstract, conjugate or nonconjugate) is returned when we construct the posterior (current behavior is that an `AbstractPosterior` is always returned). This way we get proper tab-completion and information (signatures, docstrings) when mouse-hovering on an object. 
- pass (and return) a `TypeVar` (with `Module` as the upper bound) in `fit` instead of `Module` itself, such that we retain the right static typing information about the model we are using 
