### PR TITLE
changed schedule peak_value to 1e-2 for the svgp notebook so it does not give nans

### DIFF
--- a/docs/examples/uncollapsed_vi.py
+++ b/docs/examples/uncollapsed_vi.py
@@ -256,7 +256,7 @@ negative_elbo = jit(negative_elbo)
 # %%
 schedule = ox.warmup_cosine_decay_schedule(
     init_value=0.0,
-    peak_value=0.1,
+    peak_value=0.01,
     warmup_steps=75,
     decay_steps=1500,
     end_value=0.001,


### PR DESCRIPTION


## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

Current `uncollapsed_vi.py` notebook gives me `nan`s when I run it locally with the scheduler peaked at 0.1. I have changed the `peak_value=0.01` to avoid the issue. Optimisation works as expected after that.
Issue Number: N/A
