### PR TITLE
Support for missing values using masked dataset

### DIFF
--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -45,7 +45,7 @@ class Dataset(Pytree):
         _check_shape(self.X, self.y)
         if self.y is not None and self.mask is None:
             if jnp.any(mask := jnp.isnan(self.y)):
-                self.mask = ~mask
+                self.mask = mask
 
     def __repr__(self) -> str:
         r"""Returns a string representation of the dataset."""

--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -15,7 +15,10 @@
 
 from dataclasses import dataclass
 
-from beartype.typing import Optional
+from beartype.typing import (
+    Optional,
+    Union,
+)
 import jax.numpy as jnp
 from jaxtyping import (
     Bool,
@@ -28,7 +31,6 @@ from gpjax.typing import Array
 
 class _Missing:
     """Sentinel class for not-yet-computed mask"""
-
 
 
 @dataclass
@@ -49,7 +51,7 @@ class Dataset(Pytree):
 
     X: Optional[Num[Array, "N D"]] = None
     y: Optional[Num[Array, "N Q"]] = None
-    mask: Bool[Array, "N Q"] | None = _Missing()
+    mask: Optional[Union[Bool[Array, "N Q"], None]] = _Missing()
 
     def __post_init__(self) -> None:
         r"""Checks that the shapes of $`X`$ and $`y`$ are compatible."""

--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -41,7 +41,7 @@ class Dataset(Pytree):
         y: (Optional[Num[Array, "N Q"]]): output data.
         mask: (Optional[Union[Bool[Array, "N Q"], Literal["infer automatically"]]]): mask for the output data.
             Users can optionally specify a pre-computed mask, or explicitly pass `None` which
-            means no mask will be used. Defaults to `"infer automatically"` which means that
+            means no mask will be used. Defaults to `"infer automatically"`, which means that
             the mask will be computed from the output data, or set to `None` if no output data is provided.
     """
 

--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -63,15 +63,14 @@ class Dataset(Pytree):
                     f"mask must be either the string 'infer automatically', None, or a boolean array."
                     f" Got mask={self.mask}."
                 )
-            else:
-                if self.y is not None:
-                    mask = jnp.isnan(self.y)
-                    if jnp.any(mask):
-                        self.mask = mask
-                    else:
-                        self.mask = None
+            elif self.y is not None:
+                mask = jnp.isnan(self.y)
+                if jnp.any(mask):
+                    self.mask = mask
                 else:
                     self.mask = None
+            else:
+                self.mask = None
 
     def __repr__(self) -> str:
         r"""Returns a string representation of the dataset."""

--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -38,7 +38,7 @@ class Dataset(Pytree):
 
     X: Optional[Num[Array, "N D"]] = None
     y: Optional[Num[Array, "N Q"]] = None
-    mask: Optional[Bool[Array, "N Q"]] = None
+    mask: Optional[Bool[Array, "N Q"] | bool] = None
 
     def __post_init__(self) -> None:
         r"""Checks that the shapes of $`X`$ and $`y`$ are compatible."""

--- a/gpjax/fit.py
+++ b/gpjax/fit.py
@@ -187,7 +187,7 @@ def get_batch(train_data: Dataset, batch_size: int, key: KeyArray) -> Dataset:
     # Subsample mini-batch indices with replacement.
     indices = jr.choice(key, n, (batch_size,), replace=True)
 
-    return Dataset(X=x[indices], y=y[indices], mask=mask[indices] if mask else False)
+    return Dataset(X=x[indices], y=y[indices], mask=mask[indices] if mask else None)
 
 
 def _check_model(model: Any) -> None:

--- a/gpjax/fit.py
+++ b/gpjax/fit.py
@@ -182,12 +182,12 @@ def get_batch(train_data: Dataset, batch_size: int, key: KeyArray) -> Dataset:
     -------
         Dataset: The batched dataset.
     """
-    x, y, n = train_data.X, train_data.y, train_data.n
+    x, y, n, mask = train_data.X, train_data.y, train_data.n, train_data.mask
 
     # Subsample mini-batch indices with replacement.
     indices = jr.choice(key, n, (batch_size,), replace=True)
 
-    return Dataset(X=x[indices], y=y[indices])
+    return Dataset(X=x[indices], y=y[indices], mask=mask[indices] if mask else False)
 
 
 def _check_model(model: Any) -> None:

--- a/gpjax/gaussian_distribution.py
+++ b/gpjax/gaussian_distribution.py
@@ -169,12 +169,11 @@ class GaussianDistribution(tfd.Distribution):
         sigma = self.scale
         n = mu.shape[-1]
         if mask is not None:
-            mask_ = jnp.squeeze(mask)
-            y = jnp.where(mask_, 0.0, y)
-            mu = jnp.where(mask_, 0.0, mu)
-            sigma_masked = jnp.where(mask + mask.T, 0.0, sigma.matrix)
+            y = jnp.where(mask, 0.0, y)
+            mu = jnp.where(mask, 0.0, mu)
+            sigma_masked = jnp.where(mask[None] + mask[:, None], 0.0, sigma.matrix)
             sigma = sigma.replace(
-                matrix=jnp.where(jnp.diag(mask_), 1 / (2 * jnp.pi), sigma_masked)
+                matrix=jnp.where(jnp.diag(mask), 1 / (2 * jnp.pi), sigma_masked)
             )
 
         # diff, y - µ

--- a/gpjax/gaussian_distribution.py
+++ b/gpjax/gaussian_distribution.py
@@ -158,7 +158,8 @@ class GaussianDistribution(tfd.Distribution):
         r"""Calculates the log pdf of the multivariate Gaussian.
 
         Args:
-            y (Float[Array, " N"]): The value to calculate the log probability of.
+            y (Optional[Float[Array, " N"]]): the value of which to calculate the log probability.
+            mask: (Optional[Bool[Array, " N"]]): the mask for missing values in y.
 
         Returns
         -------

--- a/gpjax/linops/dense_linear_operator.py
+++ b/gpjax/linops/dense_linear_operator.py
@@ -48,7 +48,9 @@ class DenseLinearOperator(LinearOperator):
 
     matrix: Float[Array, "N N"]
 
-    def __init__(self, matrix: Float[Array, "N N"], dtype: jnp.dtype = None) -> None:
+    def __init__(
+        self, matrix: Float[Array, "N N"], dtype: jnp.dtype = None, shape: tuple = None
+    ) -> None:
         """Initialize the covariance operator.
 
         Args:

--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -129,7 +129,9 @@ class ConjugateMLL(AbstractObjective):
         # p(y | x, θ), where θ are the model hyperparameters:
         mll = GaussianDistribution(jnp.atleast_1d(mx.squeeze()), Sigma)
 
-        return self.constant * (mll.log_prob(jnp.atleast_1d(y.squeeze())).squeeze())
+        return self.constant * (
+            mll.log_prob(jnp.atleast_1d(y.squeeze()), mask=train_data.mask).squeeze()
+        )
 
 
 class LogPosteriorDensity(AbstractObjective):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -165,7 +165,7 @@ def test_dataset_missing(n: int, in_dim: int, out_dim: int) -> None:
     x = jnp.ones((n, in_dim))
     y = jr.normal(jr.PRNGKey(123), (n, out_dim))
     y = y.at[y < 0].set(jnp.nan)
-    mask = ~jnp.isnan(y)
+    mask = jnp.isnan(y)
     D = Dataset(X=x, y=y)
 
     # Check mask
@@ -181,7 +181,7 @@ def test_dataset_missing(n: int, in_dim: int, out_dim: int) -> None:
     D2 = D + D2
 
     # Check mask
-    assert jnp.sum(~D2.mask) == jnp.sum(~D.mask)
+    assert jnp.sum(D2.mask) == jnp.sum(D.mask)
 
     # Test dataset shapes
     assert D.n == n

--- a/tests/test_gaussian_distribution.py
+++ b/tests/test_gaussian_distribution.py
@@ -149,3 +149,24 @@ def test_kl_divergence(n: int) -> None:
     with pytest.raises(ValueError):
         incompatible = GaussianDistribution(loc=jnp.ones((2 * n,)))
         incompatible.kl_divergence(dist_a)
+
+
+@pytest.mark.parametrize("n", [5, 100])
+def test_masked_log_prob(n):
+    key_mean, key_sqrt = jr.split(_key, 2)
+    mean = jr.uniform(key_mean, shape=(n,))
+    sqrt = jr.uniform(key_sqrt, shape=(n, n))
+    covariance = sqrt @ sqrt.T
+    y = jr.normal(_key, shape=(n,))
+    y = y.at[jr.choice(key_sqrt, y.shape[0], (1,))].set(jnp.nan)
+    mask = jnp.isnan(y)
+
+    # check that cholesky does not error
+    _L = jnp.linalg.cholesky(covariance)  # noqa: F841
+
+    # check that masked log_prob is equal to tfp log_prob with missing values removed
+    dist = GaussianDistribution(loc=mean, scale=DenseLinearOperator(covariance))
+    tfp_dist = MultivariateNormalFullCovariance(
+        loc=mean[~mask], covariance_matrix=covariance[~mask][:, ~mask]
+    )
+    assert approx_equal(dist.log_prob(y, mask=mask), tfp_dist.log_prob(y[~mask]))


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

This PR introduces support for missing data points (missing `y`s) in a way that is compatible with JAX jit-compilation (by keeping shapes static). This could be particularly useful in meta-learning settings (where each task has a variable number of available training points), or in multi-output GPs where only some of the outputs are missing (@ingmarschuster).

- new attribute `mask` added to the `Dataset`object
- added code to computations of `log_prob` and to posterior predictions, such that masked training inputs have no influence on the results

For now I only tested this on a simple exact GP with gaussian likelihood. 
