### PR TITLE
Precision check feature

### DIFF
--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 from dataclasses import dataclass
+import warnings
 
 from beartype.typing import Optional
 import jax.numpy as jnp
@@ -37,8 +38,10 @@ class Dataset(Pytree):
     y: Optional[Num[Array, "N Q"]] = None
 
     def __post_init__(self) -> None:
-        r"""Checks that the shapes of $`X`$ and $`y`$ are compatible."""
+        r"""Checks that the shapes of $`X`$ and $`y`$ are compatible,
+        and provides warnings regarding the precision of $`X`$ and $`y`$."""
         _check_shape(self.X, self.y)
+        _check_precision(self.X, self.y)
 
     def __repr__(self) -> str:
         r"""Returns a string representation of the dataset."""
@@ -103,6 +106,25 @@ def _check_shape(
     if y is not None and y.ndim != 2:
         raise ValueError(
             f"Outputs, y, must be a 2-dimensional array. Got y.ndim={y.ndim}."
+        )
+
+
+def _check_precision(
+    X: Optional[Num[Array, "..."]], y: Optional[Num[Array, "..."]]
+) -> None:
+    r"""Checks the precision of $`X`$ and $`y`."""
+    if X is not None and X.dtype != jnp.float64:
+        warnings.warn(
+            "Warning: X is not of type float64. "
+            f"Got X.dtype={X.dtype}. This may lead to numerical instability. ",
+            stacklevel=2,
+        )
+
+    if y is not None and y.dtype != jnp.float64:
+        warnings.warn(
+            "Warning: y is not of type float64."
+            f"Got y.dtype={y.dtype}. This may lead to numerical instability.",
+            stacklevel=2,
         )
 
 

--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -115,14 +115,14 @@ def _check_precision(
     r"""Checks the precision of $`X`$ and $`y`."""
     if X is not None and X.dtype != jnp.float64:
         warnings.warn(
-            "Warning: X is not of type float64. "
+            "X is not of type float64. "
             f"Got X.dtype={X.dtype}. This may lead to numerical instability. ",
             stacklevel=2,
         )
 
     if y is not None and y.dtype != jnp.float64:
         warnings.warn(
-            "Warning: y is not of type float64."
+            "y is not of type float64."
             f"Got y.dtype={y.dtype}. This may lead to numerical instability.",
             stacklevel=2,
         )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -186,7 +186,7 @@ def test_precision_warning(
         expected_warnings += 1
 
     with pytest.warns(
-        UserWarning, match="Warning:.*is not of type float64.*"
+        UserWarning, match=".* is not of type float64.*"
     ) as record:
         Dataset(X=x, y=y)
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [x] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

Have added a warning using the ```warnings``` package that informs when X or y isn't of dtype float64 (if the warnings package isn't appropriate then please let me know, it's a new import within ```dataset.py```). This is called immediately after checking the dataset shape:

```
    def __post_init__(self) -> None:
        r"""Checks that the shapes of $`X`$ and $`y`$ are compatible,
        and provides warnings regarding the precision of $`X`$ and $`y`$."""
        _check_shape(self.X, self.y)
       -->>  _check_precision(self.X, self.y)
```

I've added a test for the warning generation, but to do so I had to enable the higher precision within ```test_dataset.py``` (```config.update("jax_enable_x64", True)```) .  I hope this solution is alright. Thanks!


Issue Number: #342
