### PR TITLE
Fix objectives tests

### DIFF
--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,4 +1,5 @@
 import jax
+from jax.config import config
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -18,6 +19,9 @@ from gpjax.objectives import (
     LogPosteriorDensity,
     NonConjugateMLL,
 )
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 def test_abstract_objective():


### PR DESCRIPTION
Set 64 bit precision in objectives tests due to change in https://github.com/JaxGaussianProcesses/GPJax/pull/347 causing tests to fail when run in isolation.

## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [N/A] I've added tests for new code.
- [N/A] I've added docstrings for the new code.

## Description

Objectives tests were failing when run in isolation due to https://github.com/JaxGaussianProcesses/GPJax/pull/347. However, when all tests where run together they would pass (presumably due to 64 bit precision being set by an earlier set of tests). Therefore, 64 bit precision has been added to the objectives tests so that they can be run successfully in isolation.

Issue Number: N/A
