### PR TITLE
Kernel baseclass

### DIFF
--- a/gpjax/kernels/base.py
+++ b/gpjax/kernels/base.py
@@ -81,8 +81,8 @@ class AbstractKernel(Module):
     @abc.abstractmethod
     def __call__(
         self,
-        x: Float[Array, " D"],
-        y: Float[Array, " D"],
+        x: Num[Array, " D"],
+        y: Num[Array, " D"],
     ) -> ScalarFloat:
         r"""Evaluate the kernel on a pair of inputs.
 

--- a/gpjax/kernels/non_euclidean/categorical.py
+++ b/gpjax/kernels/non_euclidean/categorical.py
@@ -15,7 +15,7 @@
 
 
 from dataclasses import dataclass
-from typing import NamedTuple, Union
+from typing import NamedTuple
 import jax.numpy as jnp
 from jaxtyping import Float, Int
 import tensorflow_probability.substrates.jax as tfp

--- a/gpjax/kernels/non_euclidean/categorical.py
+++ b/gpjax/kernels/non_euclidean/categorical.py
@@ -81,10 +81,10 @@ class CatKernel(AbstractKernel):
         L = self.stddev.reshape(-1, 1) * self.cholesky_lower
         return L @ L.T
 
-    def __call__(  # TODO not consistent with general kernel interface
+    def __call__(
         self,
-        x: Union[ScalarInt, Int[Array, " N"]],
-        y: Union[ScalarInt, Int[Array, " N"]],
+        x: Int[Array, " N"],
+        y: Int[Array, " N"],
     ):
         r"""Compute the (co)variance between a pair of dictionary indices.
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

Fix signature of `AbstractKernel.__call__` to be `def __call__(self, x: Num[Array, " D"], y: Num[Array, " D"]) -> ScalarFloat:` which is more general than having `x`, `y` be float arrays.

Issue Number: N/A
