### PR TITLE
[WIP] Remove `num_datapoints` attribute from `Likelihood` class

### DIFF
--- a/gpjax/kernels/__init__.py
+++ b/gpjax/kernels/__init__.py
@@ -27,7 +27,10 @@ from gpjax.kernels.computations import (
     DiagonalKernelComputation,
     EigenKernelComputation,
 )
-from gpjax.kernels.non_euclidean import GraphKernel, CatKernel
+from gpjax.kernels.non_euclidean import (
+    CatKernel,
+    GraphKernel,
+)
 from gpjax.kernels.nonstationary import (
     ArcCosine,
     Linear,

--- a/gpjax/kernels/non_euclidean/__init__.py
+++ b/gpjax/kernels/non_euclidean/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from gpjax.kernels.non_euclidean.graph import GraphKernel
 from gpjax.kernels.non_euclidean.categorical import CatKernel
+from gpjax.kernels.non_euclidean.graph import GraphKernel
 
 __all__ = ["GraphKernel", "CatKernel"]

--- a/gpjax/kernels/non_euclidean/categorical.py
+++ b/gpjax/kernels/non_euclidean/categorical.py
@@ -15,9 +15,16 @@
 
 
 from dataclasses import dataclass
-from typing import NamedTuple, Union
+from typing import (
+    NamedTuple,
+    Union,
+)
+
 import jax.numpy as jnp
-from jaxtyping import Float, Int
+from jaxtyping import (
+    Float,
+    Int,
+)
 import tensorflow_probability.substrates.jax as tfp
 
 from gpjax.base import (
@@ -25,7 +32,6 @@ from gpjax.base import (
     static_field,
 )
 from gpjax.kernels.base import AbstractKernel
-
 from gpjax.typing import (
     Array,
     ScalarInt,

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -49,7 +49,6 @@ tfd = tfp.distributions
 class AbstractLikelihood(Module):
     r"""Abstract base class for likelihoods."""
 
-    num_datapoints: int = static_field()
     integrator: AbstractIntegrator = static_field(GHQuadratureIntegrator())
 
     def __call__(self, *args: Any, **kwargs: Any) -> tfd.Distribution:

--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -176,7 +176,7 @@ class LogPosteriorDensity(AbstractObjective):
         mx = posterior.prior.mean_function(x)
 
         # Whitened function values, wx, corresponding to the inputs, x
-        wx = posterior.latent
+        wx = posterior.get_latent(num_datapoints=n)
 
         # f(x) = mx  +  Lx wx
         fx = mx + Lx @ wx
@@ -196,6 +196,8 @@ NonConjugateMLL = LogPosteriorDensity
 
 
 class ELBO(AbstractObjective):
+    full_dataset_size: int
+
     def step(
         self,
         variational_family: "gpjax.variational_families.AbstractVariationalFamily",  # noqa: F821
@@ -229,10 +231,7 @@ class ELBO(AbstractObjective):
 
         # For batch size b, we compute  n/b * Σᵢ[ ∫log(p(y|f(xᵢ))) q(f(xᵢ)) df(xᵢ)] - KL[q(f(·)) || p(f(·))]
         return self.constant * (
-            jnp.sum(var_exp)
-            * variational_family.posterior.likelihood.num_datapoints
-            / train_data.n
-            - kl
+            jnp.sum(var_exp) * self.full_dataset_size / train_data.n - kl
         )
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -185,9 +185,7 @@ def test_precision_warning(
     if prec_y != jnp.float64:
         expected_warnings += 1
 
-    with pytest.warns(
-        UserWarning, match=".* is not of type float64.*"
-    ) as record:
+    with pytest.warns(UserWarning, match=".* is not of type float64.*") as record:
         Dataset(X=x, y=y)
 
     assert len(record) == expected_warnings

--- a/tests/test_kernels/test_non_euclidean.py
+++ b/tests/test_kernels/test_non_euclidean.py
@@ -12,11 +12,14 @@
 
 from jax.config import config
 import jax.numpy as jnp
+import jax.random as jr
 import networkx as nx
 
-from gpjax.kernels.non_euclidean import GraphKernel, CatKernel
+from gpjax.kernels.non_euclidean import (
+    CatKernel,
+    GraphKernel,
+)
 from gpjax.linops import identity
-import jax.random as jr
 
 # # Enable Float64 for more stable matrix inversions.
 config.update("jax_enable_x64", True)


### PR DESCRIPTION
It would be highly beneficial not to have a `num_datapoints` attribute associated with likelihood functions, particularly for BO functionality. This is largely used in two places:

1. `NonConjugatePosterior`  - here it is used to initialise the latent function. I propose we can remove this by adding a `get_latent()` function and making the `latent` attribute private. Now, if `get_latent()`  is called, and the `latent` function hasn't been initialised, it will be initialised with the correct number of datapoints. As far as I'm aware, the number of datapoints should be available whenever this is called.

2. `ELBO` objective - here it is used to rescale the objective if batching is used. Instead, I propose that we add a `full_dataset_size` attribute to the `ELBO` class which is supplied by the user upon initialisation (at which point the size of the full dataset should be known).

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [X] Other

## Checklist

- [X] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code - Will be added in subsequent commit.
- [ ] I've added docstrings for the new code.

## Description

It would be highly beneficial not to have a `num_datapoints` attribute associated with likelihood functions, particularly for BO functionality. This is largely used in two places:

1. `NonConjugatePosterior`  - here it is used to initialise the latent function. I propose we can remove this by adding a `get_latent()` function and making the `latent` attribute private. Now, if `get_latent()`  is called, and the `latent` function hasn't been initialised, it will be initialised with the correct number of datapoints. As far as I'm aware, the number of datapoints should be available whenever this is called.

2. `ELBO` objective - here it is used to rescale the objective if batching is used. Instead, I propose that we add a `full_dataset_size` attribute to the `ELBO` class which is supplied by the user upon initialisation (at which point the size of the full dataset should be known).

Issue Number: N/A
