### PR TITLE
Performance improvement in log_det

### DIFF
--- a/gpjax/linops/linear_operator.py
+++ b/gpjax/linops/linear_operator.py
@@ -161,7 +161,7 @@ class LinearOperator(Pytree, Generic[ShapeT, DTypeT]):
         """
         root = self.to_root()
 
-        return 2.0 * jnp.sum(jnp.log(root.diagonal()))
+        return 2.0 * jnp.log(jnp.prod(root.diagonal()))
 
     def to_root(self) -> "LinearOperator":
         """Compute the root of the linear operator via the Cholesky decomposition.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Performance

## Checklist

- [x] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

Performance improvement in the computation of `log_det` from `LinearOperator`. 

**Edit: unfortunately computing the product before the log can also result in overflow.  For small matrices this is not an issue but it is for large ones.**

```python
import timeit

import jax
import jax.numpy as jnp
import jax.random as jr
from gpjax.linops import DenseLinearOperator

jax.config.update("jax_enable_x64", True)

key = jr.PRNGKey(123)
cov = jr.normal(key, (100, 100)).astype(jnp.float64)
cov = cov @ cov.T

linop = DenseLinearOperator(cov)
root = linop.to_root()
expr1 = "jnp.sum(jnp.log(root.diagonal()))"
res1 = jnp.sum(jnp.log(root.diagonal()))
time1 = timeit.timeit(expr1, number=1000, globals=globals())

expr2 = "jnp.log(jnp.prod(root.diagonal()))"
res2 = jnp.log(jnp.prod(root.diagonal()))
time2 = timeit.timeit(expr2, number=1000, globals=globals())

print(f"'{expr1}': {time1:.3}s")
print(f"'{expr2}': {time2:.3}s")
assert res1 == res2
```
```
'jnp.sum(jnp.log(root.diagonal()))': 0.0363s
'jnp.log(jnp.prod(root.diagonal()))': 0.0178s
```