### PR TITLE
Add logic for running a decision making loop

### DIFF
--- a/gpjax/decision_making/__init__.py
+++ b/gpjax/decision_making/__init__.py
@@ -21,6 +21,10 @@ from gpjax.decision_making.acquisition_maximizer import (
     AbstractAcquisitionMaximizer,
     ContinuousAcquisitionMaximizer,
 )
+from gpjax.decision_making.decision_maker import (
+    AbstractDecisionMaker,
+    DecisionMaker,
+)
 from gpjax.decision_making.posterior_handler import PosteriorHandler
 from gpjax.decision_making.search_space import (
     AbstractSearchSpace,
@@ -32,14 +36,18 @@ from gpjax.decision_making.test_functions import (
     LogarithmicGoldsteinPrice,
     Quadratic,
 )
+from gpjax.decision_making.utils import build_function_evaluator
 
 __all__ = [
     "AbstractAcquisitionFunctionBuilder",
     "AbstractAcquisitionMaximizer",
+    "AbstractDecisionMaker",
     "AbstractSearchSpace",
     "AcquisitionFunction",
+    "build_function_evaluator",
     "ContinuousAcquisitionMaximizer",
     "ContinuousSearchSpace",
+    "DecisionMaker",
     "AbstractContinuousTestFunction",
     "Forrester",
     "LogarithmicGoldsteinPrice",

--- a/gpjax/decision_making/decision_maker.py
+++ b/gpjax/decision_making/decision_maker.py
@@ -1,0 +1,254 @@
+# Copyright 2023 The GPJax Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from dataclasses import (
+    dataclass,
+    field,
+)
+
+from beartype.typing import (
+    Callable,
+    Dict,
+    List,
+    Mapping,
+)
+import jax.random as jr
+
+from gpjax.dataset import Dataset
+from gpjax.decision_making.acquisition_functions import (
+    AbstractAcquisitionFunctionBuilder,
+)
+from gpjax.decision_making.acquisition_maximizer import AbstractAcquisitionMaximizer
+from gpjax.decision_making.posterior_handler import PosteriorHandler
+from gpjax.decision_making.search_space import AbstractSearchSpace
+from gpjax.decision_making.utils import FunctionEvaluator
+from gpjax.gps import AbstractPosterior
+from gpjax.typing import (
+    Array,
+    Float,
+    KeyArray,
+)
+
+
+@dataclass
+class AbstractDecisionMaker(ABC):
+    """
+    AbstractDecisionMaker abstract base class which handles the core decision loop. The
+    decision making loop is split into two key steps, `ask` and `tell`. The `ask`
+    step is typically used to decide which point to query next. The `tell` step is
+    typically used to update models and datasets with newly queried points.
+
+    Attributes:
+        search_space (AbstractSearchSpace): Search space which is being queried
+        posterior_handlers (Dict[str, PosteriorHandler]): Dictionary of posterior
+            handlers, which are used to update posteriors throughout the decision making
+            loop. Tags are used to distinguish between posteriors. In a typical Bayesian
+            optimisation setup one of the tags will be `OBJECTIVE`, defined in
+            decision_making.utils.
+        datasets (Dict[str, Dataset]): Dictionary of datasets, which are augmented with
+            observations throughout the decision making loop. In a typical setup they are
+            also used to fit the posteriors, using the `posterior_handlers`. Tags are used
+            to distinguish datasets, and correspond to tags in `posterior_handlers`.
+        acquisition_function_builder (AbstractAcquisitionFunctionBuilder): Object which
+            builds acquisition functions from posteriors and datasets, to decide where
+            to query next. In a typical Bayesian optimisation setup the point chosen to
+            be queried next is the point which maximizes the acquisition function.
+        acquisition_maximizer (AbstractAcquisitionMaximizer): Object which maximizes
+            acquisition functions over the search space.
+        key (KeyArray): JAX random key, used to generate random numbers.
+        post_ask (List[Callable]): List of functions to be executed after each ask step.
+        post_tell (List[Callable]): List of functions to be executed after each tell
+            step.
+    """
+
+    search_space: AbstractSearchSpace
+    posterior_handlers: Dict[str, PosteriorHandler]
+    datasets: Dict[str, Dataset]
+    acquisition_function_builder: AbstractAcquisitionFunctionBuilder
+    acquisition_maximizer: AbstractAcquisitionMaximizer
+    key: KeyArray
+    post_ask: List[Callable] = field(
+        default_factory=list
+    )  # Specific type is List[Callable[[DecisionMaker, Float[Array, ["1 D"]]], None]] but causes Beartype issues
+    post_tell: List[Callable] = field(
+        default_factory=list
+    )  # Specific type is List[Callable[[DecisionMaker], None]] but causes Beartype issues
+
+    @abstractmethod
+    def ask(self, key: KeyArray) -> Float[Array, "1 D"]:
+        """
+        In a typical decision making setup this will use the
+        `acquisition_function_builder` to form an acquisition function and then return
+        the point which maximizes the acquisition function using the
+        `acquisition_maximizer` as the point to be queried next.
+
+        Args:
+            key (KeyArray): JAX PRNG key for controlling random state.
+
+        Returns:
+            Float[Array, "1 D"]: Point to be queried next
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def tell(self, observation_datasets: Mapping[str, Dataset], key: KeyArray):
+        """
+        Tell decision maker about new observations. In a typical decision making setup
+        we will update the datasets and posteriors with the new observations.
+
+        Args:
+            observation_datasets (Mapping[str, Dataset]): Dictionary of datasets
+                containing new observations. Tags are used to distinguish datasets, and
+                correspond to tags in `posterior_handlers` in a typical setup.
+            key (KeyArray): JAX PRNG key for controlling random state.
+        """
+        raise NotImplementedError
+
+
+@dataclass
+class DecisionMaker(AbstractDecisionMaker):
+    """
+    DecisionMaker class which handles the core decision making loop in a typical setup. The
+    decision making loop is split into two key steps, `ask` and `tell`. The `ask`
+    step forms an `AcquisitionFunction` from the current `posteriors` and `datasets` and
+    returns the point which maximises it. It also stores the formed acquisition function
+    under the attribute `self.current_acquisition_function` so that it can be called,
+    for instance for plotting, after the `ask` function has been called. The `tell` step
+    adds a newly queried point to the `datasets` and updates the `posteriors`.
+
+    This can be run as a typical ask-tell loop, or the `run` method can be used to run
+    the decision making loop for a fixed number of steps. Moreover, the `run` method executes
+    the functions in `post_ask` and `post_tell` after each ask and tell step
+    respectively. This enables the user to add custom functionality, such as the ability
+    to plot values of interest during the optimization process.
+    """
+
+    def __post_init__(self):
+        """
+        At initialisation we check that the posterior handlers and datasets are
+        consistent (i.e. have the same tags), and then initialise the posteriors, optimizing them using the
+        corresponding datasets.
+        """
+        # Check that posterior handlers and datasets are consistent
+        if self.posterior_handlers.keys() != self.datasets.keys():
+            raise ValueError(
+                "Posterior handlers and datasets must have the same keys. "
+                f"Got posterior handlers keys {self.posterior_handlers.keys()} and "
+                f"datasets keys {self.datasets.keys()}."
+            )
+
+        # Initialize posteriors
+        self.posteriors: Dict[str, AbstractPosterior] = {}
+        for tag, posterior_handler in self.posterior_handlers.items():
+            self.posteriors[tag] = posterior_handler.get_posterior(
+                self.datasets[tag], optimize=True, key=self.key
+            )
+
+    def ask(self, key: KeyArray) -> Float[Array, "1 D"]:
+        """
+        Get updated acquisition function and return the point which maximises it. This
+        method also stores the acquisition function in
+        `self.current_acquisition_function` so that it can be accessed after the ask
+        function has been called. This is useful for non-deterministic acquisition
+        functions, which will differ between calls to `ask` due to the splitting of
+        `self.key`.
+
+        Args:
+            key (KeyArray): JAX PRNG key for controlling random state.
+
+        Returns:
+            Float[Array, "1 D"]: Point to be queried next.
+        """
+        self.current_acquisition_function = (
+            self.acquisition_function_builder.build_acquisition_function(
+                self.posteriors, self.datasets, key
+            )
+        )
+
+        key, _ = jr.split(key)
+        return self.acquisition_maximizer.maximize(
+            self.current_acquisition_function, self.search_space, key
+        )
+
+    def tell(self, observation_datasets: Mapping[str, Dataset], key: KeyArray):
+        """
+        Add newly observed data to datasets and update the corresponding posteriors.
+
+        Args:
+            observation_datasets (Mapping[str, Dataset]): Dictionary of datasets
+            containing new observations. Tags are used to distinguish datasets, and
+            correspond to tags in `posterior_handlers` and `self.datasets`.
+            key (KeyArray): JAX PRNG key for controlling random state.
+        """
+        if observation_datasets.keys() != self.datasets.keys():
+            raise ValueError(
+                "Observation datasets and existing datasets must have the same keys. "
+                f"Got observation datasets keys {observation_datasets.keys()} and "
+                f"existing datasets keys {self.datasets.keys()}."
+            )
+
+        for tag, observation_dataset in observation_datasets.items():
+            self.datasets[tag] += observation_dataset
+
+        for tag, posterior_handler in self.posterior_handlers.items():
+            key, _ = jr.split(key)
+            self.posteriors[tag] = posterior_handler.update_posterior(
+                self.datasets[tag], self.posteriors[tag], optimize=True, key=key
+            )
+
+    def run(
+        self, n_steps: int, black_box_function_evaluator: FunctionEvaluator
+    ) -> Mapping[str, Dataset]:
+        """
+        Run the decision making loop continuously for for `n_steps`. This is broken down
+        into three main steps:
+        1. Call the `ask` method to get the point to be queried next.
+        2. Call the `black_box_function_evaluator` to evaluate the black box functions
+        of interest at the point chosen to be queried.
+        3. Call the `tell` method to update the datasets and posteriors with the newly
+        observed data.
+
+        In addition to this, after the `ask` step, the functions in the `post_ask` list
+        are executed, taking as arguments the decision maker and the point chosen to be
+        queried next. Similarly, after the `tell` step, the functions in the `post_tell`
+        list are executed, taking the decision maker as the sole argument.
+
+        Args:
+            n_steps (int): Number of steps to run the decision making loop for.
+            black_box_function_evaluator (FunctionEvaluator): Function evaluator which
+                evaluates the black box functions of interest at supplied points.
+
+        Returns:
+            Mapping[str, Dataset]: Dictionary of datasets containing the observations
+            made throughout the decision making loop, as well as the initial data
+            supplied when initialising the `DecisionMaker`.
+        """
+        for _ in range(n_steps):
+            query_point = self.ask(self.key)
+
+            for post_ask_method in self.post_ask:
+                post_ask_method(self, query_point)
+
+            self.key, _ = jr.split(self.key)
+            observation_datasets = black_box_function_evaluator(query_point)
+            self.tell(observation_datasets, self.key)
+
+            for post_tell_method in self.post_tell:
+                post_tell_method(self)
+
+        return self.datasets

--- a/gpjax/decision_making/utils.py
+++ b/gpjax/decision_making/utils.py
@@ -12,6 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from beartype.typing import Final
+from beartype.typing import (
+    Callable,
+    Dict,
+    Final,
+)
+
+from gpjax.dataset import Dataset
+from gpjax.typing import (
+    Array,
+    Float,
+)
 
 OBJECTIVE: Final[str] = "OBJECTIVE"
+"""
+Tag for the objective dataset/function in standard acquisition functions.
+"""
+
+
+FunctionEvaluator = Callable[[Float[Array, "N D"]], Dict[str, Dataset]]
+"""
+Type alias for function evaluators, which take an array of points of shape $`[N, D]`$
+and evaluate a set of functions at each point, returning a mapping from function tags
+to datasets of the evaluated points. This is the same as the `Observer` in Trieste:
+https://github.com/secondmind-labs/trieste/blob/develop/trieste/observer.py
+"""
+
+
+def build_function_evaluator(
+    functions: Dict[str, Callable[[Float[Array, "N D"]], Float[Array, "N 1"]]]
+) -> FunctionEvaluator:
+    """
+    Takes a dictionary of functions and returns a `FunctionEvaluator` which can be
+    used to evaluate each of the functions at a supplied set of points and return a
+    dictionary of datasets storing the evaluated points.
+    """
+    return lambda x: {tag: Dataset(x, f(x)) for tag, f in functions.items()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,6 @@ select = [
   "TID",
   # implicit string concatenation
   "ISC",
-  # type-checking imports
-  "TCH",
 ]
 ignore = [
     # space before : (needed for how black formats slicing)

--- a/tests/test_decision_making/test_decision_maker.py
+++ b/tests/test_decision_making/test_decision_maker.py
@@ -1,0 +1,330 @@
+# Copyright 2023 The JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import jax.random as jr
+import optax as ox
+import pytest
+
+import gpjax as gpx
+from gpjax.dataset import Dataset
+from gpjax.decision_making.acquisition_functions import (
+    AbstractAcquisitionFunctionBuilder,
+)
+from gpjax.decision_making.acquisition_maximizer import (
+    AbstractAcquisitionMaximizer,
+    ContinuousAcquisitionMaximizer,
+)
+from gpjax.decision_making.decision_maker import (
+    AbstractDecisionMaker,
+    DecisionMaker,
+)
+from gpjax.decision_making.posterior_handler import PosteriorHandler
+from gpjax.decision_making.search_space import (
+    AbstractSearchSpace,
+    ContinuousSearchSpace,
+)
+from gpjax.decision_making.test_functions import Quadratic
+from gpjax.decision_making.utils import (
+    OBJECTIVE,
+    build_function_evaluator,
+)
+from gpjax.typing import KeyArray
+from tests.test_decision_making.utils import QuadraticAcquisitionFunctionBuilder
+
+CONSTRAINT = "CONSTRAINT"
+
+
+@pytest.fixture
+def search_space() -> ContinuousSearchSpace:
+    return ContinuousSearchSpace(
+        lower_bounds=jnp.array([0.0], dtype=jnp.float64),
+        upper_bounds=jnp.array([1.0], dtype=jnp.float64),
+    )
+
+
+@pytest.fixture
+def posterior_handler() -> PosteriorHandler:
+    mean = gpx.Zero()
+    kernel = gpx.Matern52(lengthscale=jnp.array(1.0), variance=jnp.array(1.0))
+    prior = gpx.Prior(mean_function=mean, kernel=kernel)
+    likelihood_builder = lambda x: gpx.Gaussian(
+        num_datapoints=x, obs_noise=jnp.array(1e-6)
+    )
+    posterior_handler = PosteriorHandler(
+        prior=prior,
+        likelihood_builder=likelihood_builder,
+        optimization_objective=gpx.ConjugateMLL(negative=True),
+        optimizer=ox.adam(learning_rate=0.01),
+        num_optimization_iters=100,
+    )
+    return posterior_handler
+
+
+@pytest.fixture
+def acquisition_function_builder() -> AbstractAcquisitionFunctionBuilder:
+    return QuadraticAcquisitionFunctionBuilder()
+
+
+@pytest.fixture
+def acquisition_maximizer() -> AbstractAcquisitionMaximizer:
+    return ContinuousAcquisitionMaximizer(num_initial_samples=1000, num_restarts=1)
+
+
+def get_dataset(num_points: int, key: KeyArray) -> Dataset:
+    test_function = Quadratic()
+    dataset = test_function.generate_dataset(num_points=num_points, key=key)
+    return dataset
+
+
+def test_abstract_decision_maker_raises_error():
+    with pytest.raises(TypeError):
+        AbstractDecisionMaker()
+
+
+@pytest.mark.filterwarnings(
+    "ignore::UserWarning"
+)  # Sampling with tfp causes JAX to raise a UserWarning due to some internal logic around jnp.argsort
+def test_invalid_tags_raises_error(
+    search_space: AbstractSearchSpace,
+    posterior_handler: PosteriorHandler,
+    acquisition_function_builder: AbstractAcquisitionFunctionBuilder,
+    acquisition_maximizer: AbstractAcquisitionMaximizer,
+):
+    key = jr.PRNGKey(42)
+    posterior_handlers = {OBJECTIVE: posterior_handler}
+    dataset = get_dataset(num_points=5, key=jr.PRNGKey(42))
+    datasets = {"CONSTRAINT": dataset}  # Dataset tag doesn't match posterior tag
+    with pytest.raises(ValueError):
+        DecisionMaker(
+            search_space=search_space,
+            posterior_handlers=posterior_handlers,
+            datasets=datasets,
+            acquisition_function_builder=acquisition_function_builder,
+            acquisition_maximizer=acquisition_maximizer,
+            key=key,
+        )
+
+
+@pytest.mark.filterwarnings(
+    "ignore::UserWarning"
+)  # Sampling with tfp causes JAX to raise a UserWarning due to some internal logic around jnp.argsort
+def test_initialisation_optimizes_posterior_hyperparameters(
+    search_space: AbstractSearchSpace,
+    posterior_handler: PosteriorHandler,
+    acquisition_function_builder: AbstractAcquisitionFunctionBuilder,
+    acquisition_maximizer: AbstractAcquisitionMaximizer,
+):
+    key = jr.PRNGKey(42)
+    posterior_handlers = {OBJECTIVE: posterior_handler, CONSTRAINT: posterior_handler}
+    objective_dataset = get_dataset(num_points=5, key=jr.PRNGKey(42))
+    constraint_dataset = get_dataset(num_points=5, key=jr.PRNGKey(10))
+    datasets = {"OBJECTIVE": objective_dataset, CONSTRAINT: constraint_dataset}
+    decision_maker = DecisionMaker(
+        search_space=search_space,
+        posterior_handlers=posterior_handlers,
+        datasets=datasets,
+        acquisition_function_builder=acquisition_function_builder,
+        acquisition_maximizer=acquisition_maximizer,
+        key=key,
+    )
+    # Assert kernel hyperparameters get changed from their initial values
+    assert decision_maker.posteriors[OBJECTIVE].prior.kernel.lengthscale != jnp.array(
+        1.0
+    )
+    assert decision_maker.posteriors[OBJECTIVE].prior.kernel.variance != jnp.array(1.0)
+    assert decision_maker.posteriors[CONSTRAINT].prior.kernel.lengthscale != jnp.array(
+        1.0
+    )
+    assert decision_maker.posteriors[CONSTRAINT].prior.kernel.variance != jnp.array(1.0)
+    assert (
+        decision_maker.posteriors[CONSTRAINT].prior.kernel.lengthscale
+        != decision_maker.posteriors[OBJECTIVE].prior.kernel.lengthscale
+    )
+    assert (
+        decision_maker.posteriors[CONSTRAINT].prior.kernel.variance
+        != decision_maker.posteriors[OBJECTIVE].prior.kernel.variance
+    )
+
+
+@pytest.mark.filterwarnings(
+    "ignore::UserWarning"
+)  # Sampling with tfp causes JAX to raise a UserWarning due to some internal logic around jnp.argsort
+def test_decision_maker_ask(
+    search_space: AbstractSearchSpace,
+    posterior_handler: PosteriorHandler,
+    acquisition_function_builder: AbstractAcquisitionFunctionBuilder,
+    acquisition_maximizer: AbstractAcquisitionMaximizer,
+):
+    key = jr.PRNGKey(42)
+    posterior_handlers = {OBJECTIVE: posterior_handler}
+    objective_dataset = get_dataset(num_points=5, key=jr.PRNGKey(42))
+    datasets = {"OBJECTIVE": objective_dataset}
+    decision_maker = DecisionMaker(
+        search_space=search_space,
+        posterior_handlers=posterior_handlers,
+        datasets=datasets,
+        acquisition_function_builder=acquisition_function_builder,
+        acquisition_maximizer=acquisition_maximizer,
+        key=key,
+    )
+    initial_decision_maker_key = decision_maker.key
+    query_point = decision_maker.ask(key=key)
+    assert query_point.shape == (1, 1)
+    assert jnp.allclose(query_point, jnp.array([[0.5]]), atol=1e-5)
+    assert decision_maker.current_acquisition_function is not None
+    assert (
+        decision_maker.key == initial_decision_maker_key
+    ).all()  # Ensure decision maker key is unchanged
+
+
+@pytest.mark.filterwarnings(
+    "ignore::UserWarning"
+)  # Sampling with tfp causes JAX to raise a UserWarning due to some internal logic around jnp.argsort
+def test_decision_maker_tell_with_inconsistent_observations_raises_error(
+    search_space: AbstractSearchSpace,
+    posterior_handler: PosteriorHandler,
+    acquisition_function_builder: AbstractAcquisitionFunctionBuilder,
+    acquisition_maximizer: AbstractAcquisitionMaximizer,
+):
+    key = jr.PRNGKey(42)
+    posterior_handlers = {OBJECTIVE: posterior_handler, CONSTRAINT: posterior_handler}
+    initial_objective_dataset = get_dataset(num_points=5, key=jr.PRNGKey(42))
+    initial_constraint_dataset = get_dataset(num_points=5, key=jr.PRNGKey(10))
+    datasets = {
+        "OBJECTIVE": initial_objective_dataset,
+        CONSTRAINT: initial_constraint_dataset,
+    }
+    decision_maker = DecisionMaker(
+        search_space=search_space,
+        posterior_handlers=posterior_handlers,
+        datasets=datasets,
+        acquisition_function_builder=acquisition_function_builder,
+        acquisition_maximizer=acquisition_maximizer,
+        key=key,
+    )
+    mock_objective_observation = get_dataset(num_points=1, key=jr.PRNGKey(1))
+    mock_constraint_observation = get_dataset(num_points=1, key=jr.PRNGKey(2))
+    observations = {
+        OBJECTIVE: mock_objective_observation,
+        "CONSTRAINT_ONE": mock_constraint_observation,  # Deliberately incorrect tag
+    }
+    with pytest.raises(ValueError):
+        decision_maker.tell(observation_datasets=observations, key=key)
+
+
+@pytest.mark.filterwarnings(
+    "ignore::UserWarning"
+)  # Sampling with tfp causes JAX to raise a UserWarning due to some internal logic around jnp.argsort
+def test_decision_maker_tell_updates_datasets_and_models(
+    search_space: AbstractSearchSpace,
+    posterior_handler: PosteriorHandler,
+    acquisition_function_builder: AbstractAcquisitionFunctionBuilder,
+    acquisition_maximizer: AbstractAcquisitionMaximizer,
+):
+    key = jr.PRNGKey(42)
+    posterior_handlers = {OBJECTIVE: posterior_handler, CONSTRAINT: posterior_handler}
+    initial_objective_dataset = get_dataset(num_points=5, key=jr.PRNGKey(42))
+    initial_constraint_dataset = get_dataset(num_points=5, key=jr.PRNGKey(10))
+    datasets = {
+        "OBJECTIVE": initial_objective_dataset,
+        CONSTRAINT: initial_constraint_dataset,
+    }
+    decision_maker = DecisionMaker(
+        search_space=search_space,
+        posterior_handlers=posterior_handlers,
+        datasets=datasets,
+        acquisition_function_builder=acquisition_function_builder,
+        acquisition_maximizer=acquisition_maximizer,
+        key=key,
+    )
+    initial_decision_maker_key = decision_maker.key
+    initial_objective_posterior = decision_maker.posteriors[OBJECTIVE]
+    initial_constraint_posterior = decision_maker.posteriors[CONSTRAINT]
+    mock_objective_observation = get_dataset(num_points=1, key=jr.PRNGKey(1))
+    mock_constraint_observation = get_dataset(num_points=1, key=jr.PRNGKey(2))
+    observations = {
+        OBJECTIVE: mock_objective_observation,
+        CONSTRAINT: mock_constraint_observation,
+    }
+    decision_maker.tell(observation_datasets=observations, key=key)
+    assert decision_maker.datasets[OBJECTIVE].n == 6
+    assert decision_maker.datasets[CONSTRAINT].n == 6
+    assert decision_maker.datasets[OBJECTIVE].X[-1] == mock_objective_observation.X[0]
+    assert decision_maker.datasets[CONSTRAINT].X[-1] == mock_constraint_observation.X[0]
+    assert (
+        decision_maker.posteriors[OBJECTIVE].prior.kernel.lengthscale
+        != initial_objective_posterior.prior.kernel.lengthscale
+    )
+    assert (
+        decision_maker.posteriors[OBJECTIVE].prior.kernel.variance
+        != initial_objective_posterior.prior.kernel.variance
+    )
+    assert (
+        decision_maker.posteriors[CONSTRAINT].prior.kernel.lengthscale
+        != initial_constraint_posterior.prior.kernel.lengthscale
+    )
+    assert (
+        decision_maker.posteriors[CONSTRAINT].prior.kernel.variance
+        != initial_constraint_posterior.prior.kernel.variance
+    )
+    assert (
+        decision_maker.key == initial_decision_maker_key
+    ).all()  # Ensure decision maker key has not been updated
+
+
+@pytest.mark.parametrize("n_steps", [1, 3])
+@pytest.mark.filterwarnings(
+    "ignore::UserWarning"
+)  # Sampling with tfp causes JAX to raise a UserWarning due to some internal logic around jnp.argsort
+def test_decision_maker_run(
+    search_space: AbstractSearchSpace,
+    posterior_handler: PosteriorHandler,
+    acquisition_function_builder: AbstractAcquisitionFunctionBuilder,
+    acquisition_maximizer: AbstractAcquisitionMaximizer,
+    n_steps: int,
+):
+    key = jr.PRNGKey(42)
+    posterior_handlers = {OBJECTIVE: posterior_handler}
+    initial_objective_dataset = get_dataset(num_points=5, key=jr.PRNGKey(42))
+    datasets = {
+        "OBJECTIVE": initial_objective_dataset,
+    }
+    decision_maker = DecisionMaker(
+        search_space=search_space,
+        posterior_handlers=posterior_handlers,
+        datasets=datasets,
+        acquisition_function_builder=acquisition_function_builder,
+        acquisition_maximizer=acquisition_maximizer,
+        key=key,
+    )
+    initial_decision_maker_key = decision_maker.key
+    black_box_fn = Quadratic()
+    black_box_function_evaluator = build_function_evaluator(
+        {OBJECTIVE: black_box_fn.evaluate}
+    )
+    query_datasets = decision_maker.run(
+        n_steps=n_steps, black_box_function_evaluator=black_box_function_evaluator
+    )
+    assert query_datasets[OBJECTIVE].n == 5 + n_steps
+    assert (
+        jnp.abs(query_datasets[OBJECTIVE].X[-n_steps:] - jnp.array([[0.5]])) < 1e-5
+    ).all()  # Ensure we're querying the correct point in our dummy acquisition function at each step
+    assert (
+        decision_maker.key != initial_decision_maker_key
+    ).all()  # Ensure decision maker key gets updated

--- a/tests/test_decision_making/test_utils.py
+++ b/tests/test_decision_making/test_utils.py
@@ -1,0 +1,46 @@
+# Copyright 2023 The JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+
+from gpjax.decision_making.utils import (
+    OBJECTIVE,
+    build_function_evaluator,
+)
+from gpjax.typing import (
+    Array,
+    Float,
+)
+
+
+def test_build_function_evaluator():
+    def _square(x: Float[Array, "N 1"]) -> Float[Array, "N 1"]:
+        return x**2
+
+    def _cube(x: Float[Array, "N 1"]) -> Float[Array, "N 1"]:
+        return x**3
+
+    functions = {OBJECTIVE: _square, "CONSTRAINT": _cube}
+    fn_evaluator = build_function_evaluator(functions)
+    x = jnp.array([[2.0, 3.0]])
+    datasets = fn_evaluator(x)
+    assert datasets.keys() == functions.keys()
+    assert jnp.equal(datasets[OBJECTIVE].X, x).all()
+    assert jnp.equal(datasets[OBJECTIVE].y, _square(x)).all()
+    assert jnp.equal(datasets["CONSTRAINT"].X, x).all()
+    assert jnp.equal(datasets["CONSTRAINT"].y, _cube(x)).all()

--- a/tests/test_decision_making/utils.py
+++ b/tests/test_decision_making/utils.py
@@ -1,0 +1,45 @@
+# Copyright 2023 The JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from beartype.typing import Mapping
+
+from gpjax.dataset import Dataset
+from gpjax.decision_making.acquisition_functions import (
+    AbstractAcquisitionFunctionBuilder,
+    AcquisitionFunction,
+)
+from gpjax.decision_making.test_functions import Quadratic
+from gpjax.gps import ConjugatePosterior
+from gpjax.typing import KeyArray
+
+
+class QuadraticAcquisitionFunctionBuilder(AbstractAcquisitionFunctionBuilder):
+    """
+    Dummy acquisition function builder for testing purposes, which returns the negative
+    of the value of a quadratic test function at the input points. This is because
+    acquisition functions are *maximised*, and we wish to *minimise* the quadratic test
+    function.
+    """
+
+    def build_acquisition_function(
+        self,
+        posteriors: Mapping[str, ConjugatePosterior],
+        datasets: Mapping[str, Dataset],
+        key: KeyArray,
+    ) -> AcquisitionFunction:
+        test_function = Quadratic()
+        return lambda x: -1.0 * test_function.evaluate(
+            x
+        )  # Acquisition functions are *maximised*


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [X] I've added tests for new code.
- [X] I've added docstrings for the new code.

## Description

Add logic for running a decision making loop
    
Added an `AbstractDecisionMaker` abstract base class which can be
implemented in order to define a decision making loop.

A concrete implementation, in the form of a `DecisionMaker` class,
has been added. At its heart it has two core methods:
1. `ask` which is used to get a point to be queried next.
2. `tell` which is used to tell the `DecisionMaker` about new
   observations. In a typical decision making setup this will result in
   the datsets and posteriors being updated.

In addition to this, in the `DecisionMaker` a `run` method is provided,
which will automatically run the decision making loop for n steps. After
the `ask` step, the functions in the `post_ask` list will be executed,
taking as arguments the decision maker and the point chosen to be
queried next. Similarly, after the `tell` step, the functions in
the `post_tell` list are executed, taking the decision maker as the sole
argument.

Also removed the check for type-checking import warnings (TCH) from Ruff in `pyproject.toml`.

Issue Number: N/A
