### PR TITLE
Prepare for future batching

### DIFF
--- a/docs/examples/decision_making.py
+++ b/docs/examples/decision_making.py
@@ -1,0 +1,387 @@
+# %% [markdown]
+# # Introduction to Decision Making with GPJax
+#
+# In this notebook we provide an introduction to the decision making module of GPJax,
+# which can be used to solve sequential decision making problems. Common examples of
+# such problems include Bayesian optimisation (BO) and experimental design. For an
+# in-depth introduction to Bayesian optimisation itself, be sure to checkout out our
+# [Introduction to BO
+# Notebook](https://docs.jaxgaussianprocesses.com/examples/bayesian_optimisation/).
+#
+# We'll be using BO as a case study to demonstrate how one may use the decision making
+# module to solve sequential decision making problems. The goal of the decision making
+# module is to provide a set of tools that can easily be used to solve a wide range of
+# sequential decision making problems. The module is designed to be modular, and so it is
+# easy to swap out different components of the decision making pipeline. Whilst it
+# provides the functionality for quickly implementing a typical deicision making loop out
+# of the box, we also hope that it will provide sufficient flexibility to allow users to
+# define their own, more exotic, decision making pipelines.
+
+# %%
+# Enable Float64 for more stable matrix inversions.
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+
+import jax.numpy as jnp
+import jax.random as jr
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import optax as ox
+
+import gpjax as gpx
+from gpjax.decision_making.utility_functions import (
+    ThompsonSampling,
+)
+from gpjax.decision_making.utility_maximizer import (
+    ContinuousSinglePointUtilityMaximizer,
+)
+from gpjax.decision_making.decision_maker import UtilityDrivenDecisionMaker
+from gpjax.decision_making.utils import (
+    OBJECTIVE,
+    build_function_evaluator,
+)
+from gpjax.decision_making.posterior_handler import PosteriorHandler
+from gpjax.decision_making.search_space import ContinuousSearchSpace
+from gpjax.typing import (
+    Array,
+    Float,
+)
+
+key = jr.PRNGKey(42)
+plt.style.use(
+    "https://raw.githubusercontent.com/JaxGaussianProcesses/GPJax/main/docs/examples/gpjax.mplstyle"
+)
+cols = mpl.rcParams["axes.prop_cycle"].by_key()["color"]
+
+
+# %% [markdown]
+# ## The Black-Box Objective Function
+#
+# We'll be using the same problem as in the [Introduction to BO
+# Notebook](https://docs.jaxgaussianprocesses.com/examples/bayesian_optimisation/), but
+# rather than focussing on the mechanics of BO we'll be looking at how one may use the
+# abstractions provided by the decision making module to implement the BO loop.
+#
+# In BO, and sequential decision making in general, we will often have a black-box
+# function of interest which we can evaluate. In this notebook we'll be using the
+# Forrester function as our objective to minimise:
+#
+# $$f(x) = (6x - 2)^2\sin(12x-4)$$
+
+
+# %%
+def forrester(x: Float[Array, "N 1"]) -> Float[Array, "N 1"]:
+    return (6 * x - 2) ** 2 * jnp.sin(12 * x - 4)
+
+
+# %% [markdown]
+# Within the decision making loop, we'll be querying the black-box objective function many
+# times, and will often use the observed values to fit some probabilistic model. Thereore,
+# it would be useful to have some method to which we can pass a set of points which we
+# wish to query the black-box function at, and which will return a GPJax `Dataset` object
+# containing the observations. We can use the `build_function_evaluator` function provided
+# in `decision_making.utils` to do this. This function takes as input a dictionary of
+# labelled black-box functions, and will return a function evaluator, which can be called
+# with a set of points to evaluate the black-box functions at. The function evaluator will
+# return a dictionary of labelled `Dataset` objects containing the observations. Note that
+# in our case we only have one black-box function of interest, but in general we may have
+# multiple different black-box functions, such as if we also have constraint functions.
+# The use of the labels inside the dictionary returned by the function evaluator enables
+# us to easily distinguish between these different observations.
+
+# %%
+function_evaluator = build_function_evaluator({OBJECTIVE: forrester})
+
+# %% [markdown]
+# ## The Search Space
+#
+# Having defined a method for evaluating the black-box function, we now need to define the
+# search space over which we wish to optimise. In this case we'll be optimising over the
+# interval $[0, 1]$. We can use the `ContinuousSearchSpace` class provided in
+# `decision_making.search_space` to define this search space, as seen below:
+
+# %%
+lower_bounds = jnp.array([0.0])
+upper_bounds = jnp.array([1.0])
+search_space = ContinuousSearchSpace(
+    lower_bounds=lower_bounds, upper_bounds=upper_bounds
+)
+
+# %% [markdown]
+# The `ContinuousSearchSpace` class defines a `sample` method, which can be used to
+# sample points from the search space using a space-filling design, in this case using the
+# [Halton sequence](https://en.wikipedia.org/wiki/Halton_sequence). This will be useful at
+# many points throughout the decision making loop, but for now let's use it to create an
+# initial set of points which we can use to fit our models:
+
+# %%
+initial_x = search_space.sample(5, key)
+initial_datasets = function_evaluator(initial_x)
+
+# %% [markdown]
+# ## The Surrogate Models
+
+# %% [markdown]
+# Many sequential decision making algorithms are described as being *model-based*. With
+# these algorithms, we use a probabilistic model, or multiple models, to drive the
+# decision making process. In ordinary BO, a probabilistic model is used to model the
+# objective function, and it is updated based on observations from the black-box objective
+# function. These models are often referred to as *surrogate models*, and are used to
+# approximate the functions of interest. We'll be using the Gaussian process functionality
+# provided by GPJax to define our surrogate models, with some wrappers provided by the
+# `decision_making` module to make it easier to use these models within the decision
+# making loop. We can proceed as usual when defining our priors, choosing a suitable
+# mean function and kernel for the job at hand:
+
+# %%
+mean = gpx.Zero()
+kernel = gpx.Matern52()
+prior = gpx.Prior(mean_function=mean, kernel=kernel)
+
+# %% [markdown]
+# One difference from GPJax is the way in which we define our likelihood. In GPJax, we
+# construct our GP posteriors by defining a `likelihood` object and then multiplying it
+# with our prior to get the posterior, `posterior = likelihood * prior`. However, the
+# `AbstractLikelihood` objects takes `num_datapoints` as one of its arguments, and this is
+# going to be changing in the case of BO, and decision making in general, as we keep
+# updating our models having observed new data! In order to deal with this we'll define a
+# `likelihood_builder`, which takes as an argument the number of datapoints used to
+# condition our prior on, and returns a `likelihood` object. Below we use this to
+# construct a `likelihood_builder` which will return a `Gaussian` likelihood, initialised
+# with the correct number of datapoints:
+
+# %%
+likelihood_builder = lambda n: gpx.Gaussian(num_datapoints=n, obs_noise=jnp.array(1e-6))
+
+# %% [markdown]
+# Now we have all the components required for constructing our GP posterior. Since we'll
+# be updating the posterior throughout the decision making loop as we observe more data,
+# it would be useful to have an object which can handle all this logic for us.
+# Fortunately, the `decision_making` module provides the `PosteriorHandler` class to do
+# this for us. This class takes as input a `prior` and `likeligood_builder`, which we have
+# defined above. We tend to also optimise the hyperparameters of the GP prior when
+# "fitting" our GP, as demonstrated in the [Regression
+# notebook](https://docs.jaxgaussianprocesses.com/examples/regression/). This will be
+# using the GPJax `fit` method under the hood, which requires an `optimization_objective`,
+# `optimizer` and `num_optimization_iters`. Therefore, we also pass these to the
+# `PosteriorHandler` as demonstrated below:
+
+# %%
+posterior_handler = PosteriorHandler(
+    prior,
+    likelihood_builder=likelihood_builder,
+    optimization_objective=gpx.ConjugateMLL(negative=True),
+    optimizer=ox.adam(learning_rate=0.01),
+    num_optimization_iters=1000,
+)
+posterior_handlers = {OBJECTIVE: posterior_handler}
+
+# %% [markdown]
+# Note that we also create a labelled dictionary of `posterior_handlers`. This is a
+# recurring theme with the decision making logic; we can have dictionaries containing
+# datasets, posteriors and black box functions, and use labels to identify corresponding
+# objects the dictionaries. For instance, here we have an "OBJECTIVE" posterior handler
+# which is updated using the data in the "OBJECTIVE" dataset, which is in turn generated by the "OBJECTIVE" black-box function.
+#
+# Now, as the decision making loop progresses, we can use the `update_posterior` method of
+# the `PosteriorHandler` to update our posterior as we observe more data. Note that we use
+# the term *posterior* to refer to our GP posterior surrogate models in order to be
+# consistent with the syntax used by GPJax. However, these GP posteriors are more widely
+# referred to as *models* in the model-based decision making literature.
+
+# %% [markdown]
+# ## The Utility Function
+#
+# Now all that remains for us to define is the utiliy function, and a way of maximising
+# it. Within the utility-driven decision making framework, we define a utility function,
+# often using our GP surrogates, which characterises the *utility*, or *usefulness*, of
+# querying the black-box function at any point within the domain of interest. We can then
+# *maximise* this function to decide which point to query next. In this case we'll be
+# using Thompson sampling as a utility function for determining where to query next. With
+# this function we simply draw a sample from the GP posterior, and choose the minimizer
+# of the sample as the point to query next. In the `decision_making` framework we create
+# `UtilityFunctionBuilder` objects. Currently, we only support
+# `SinglePointUtilityFunction`s, which are utility functions which characterise the
+# utility of querying a single point. Thompson sampling is somewhat of a special case, as
+# we can draw $B$ independent samples from the GP posterior and optimise each of these
+# samples in order to obtain a *batch* of points to query next. We'll see an example of
+# this later on.
+#
+# Within the `ThompsonSampling` utility function builder class we implement the
+# `build_utility_function` method, which takes as input a dictionary containing lablled GP
+# posteriors, as well as the corresponding datasets for these posteriors, and draws an
+# approximate sample from the GP posterior which is a surrogate for the objective
+# function. We instantiate our utility function builder below, specifying the number of
+# Random Fourier features to use when constructing the approximate samples from the GP posterior:
+
+# %%
+utility_function_builder = ThompsonSampling(num_features=500)
+
+# %% [markdown]
+# We also need a method for maximising the utility function. Since `ThompsonSampling` is
+# classed as a `SinglePointUtilityFunction`, we can use the
+# `ContinuousSinglePointUtilityMaximizer` to maximise it. This requires the user to
+# specify `num_initial_samples` and `num_restarts` when instantiating it. This first
+# queries the utility function at `num_initial_samples` points, and then uses the best of
+# these points as a starting point for L-BFGS-B, a gradient-based optimiser, to further
+# refine. This is repeated `num_restarts` times, each time sampling a different initial set
+# of `num_initial_samples` and the best point found is returned. We'll instantiate our
+# maximiser below:
+
+# %%
+acquisition_maximizer = ContinuousSinglePointUtilityMaximizer(
+    num_initial_samples=100, num_restarts=1
+)
+
+
+# %% [markdown]
+# ## Putting it All Together with the Decision Maker
+#
+# We now have all the ingredients ready for our Bayesian optimisation loop, so let's put
+# all the logic together using the `UtilityDrivenDecisionMaker` class provided by the
+# `decision_making` module. This class has 3 core methods:
+# 1. `ask` - This method is used to decide which point(s) to query next.
+# 2. `tell` - This method is used to tell the decision maker the results from querying the
+#    black-box function at the points returned by `ask`, and will often update GP
+#    posteriors in light of this data.
+# 3. `run` - This is used to run the decision making loop for a specified number of
+#    iterations, alternating between `ask` and `tell`.
+#
+# For many decision making problems, the logic provided in the
+# `UtilityDrivenDecisionMaker` will be sufficient, and is a convenient way of gluing the
+# various bits of machinery involved in sequential decision making together. However, for
+# more exotic decision making loops, it is easy for the user to define their own decision
+# maker class by inheriting from the `AbstractDecisionMaker` class and defining their own
+# `ask`, `tell` and `run` methods.
+#
+# However, we do also provide the user with some additional flexibility when using the
+# `UtilityDrivenDecisionMaker` class. Often we may wish to perform certain actions after
+# the `ask` step and the `tell` step, such as plotting the acquisition function and the
+# point chosen to be queried for debugging purposes. We can do this by passing a list of
+# functions to be called at each of these points as the `post_ask` and `post_tell`
+# attributes of the `UtilityDrivenDecisionMaker`. Both sets of functions are called with
+# the `UtilityDrivenDecisionMaker` as an argument, and so have access to all the
+# attributes of the decision maker. The `post_ask` functions are additionally passed the
+# most recently queried points too. We'll use this functionality to plot the acquisition
+# function and the point chosen to be queried at each step of the decision making loop:
+
+
+# %%
+def plot_bo_iteration(
+    dm: UtilityDrivenDecisionMaker, last_queried_points: Float[Array, "B D"]
+):
+    posterior = dm.posteriors[OBJECTIVE]
+    dataset = dm.datasets[OBJECTIVE]
+    plt_x = jnp.linspace(0, 1, 1000).reshape(-1, 1)
+    forrester_y = forrester(plt_x.squeeze(axis=-1))
+    utility_fn = dm.current_utility_functions[0]
+    sample_y = -utility_fn(plt_x)
+
+    latent_dist = posterior.predict(plt_x, train_data=dataset)
+    predictive_dist = posterior.likelihood(latent_dist)
+
+    predictive_mean = predictive_dist.mean()
+    predictive_std = predictive_dist.stddev()
+
+    fig, ax = plt.subplots()
+    ax.plot(plt_x.squeeze(), predictive_mean, label="Predictive Mean", color=cols[1])
+    ax.fill_between(
+        plt_x.squeeze(),
+        predictive_mean - 2 * predictive_std,
+        predictive_mean + 2 * predictive_std,
+        alpha=0.2,
+        label="Two sigma",
+        color=cols[1],
+    )
+    ax.plot(
+        plt_x.squeeze(),
+        predictive_mean - 2 * predictive_std,
+        linestyle="--",
+        linewidth=1,
+        color=cols[1],
+    )
+    ax.plot(
+        plt_x.squeeze(),
+        predictive_mean + 2 * predictive_std,
+        linestyle="--",
+        linewidth=1,
+        color=cols[1],
+    )
+    ax.plot(plt_x.squeeze(), sample_y, label="Posterior Sample")
+    ax.plot(
+        plt_x.squeeze(),
+        forrester_y,
+        label="Forrester Function",
+        color=cols[0],
+        linestyle="--",
+        linewidth=2,
+    )
+    ax.axvline(x=0.757, linestyle=":", color=cols[3], label="True Optimum")
+    ax.scatter(dataset.X, dataset.y, label="Observations", color=cols[2], zorder=2)
+    ax.scatter(
+        last_queried_points[0],
+        -utility_fn(last_queried_points[0][None, ...]),
+        label="Posterior Sample Optimum",
+        marker="*",
+        color=cols[3],
+        zorder=3,
+    )
+    ax.legend(loc="center left", bbox_to_anchor=(0.950, 0.5))
+    plt.show()
+
+
+# %% [markdown]
+# Now let's put it all together and run our decision making loop for 6 iterations, with a
+# batch size of 1:
+
+# %%
+dm = UtilityDrivenDecisionMaker(
+    search_space=search_space,
+    posterior_handlers=posterior_handlers,
+    datasets=initial_datasets,
+    utility_function_builder=utility_function_builder,
+    utility_maximizer=acquisition_maximizer,
+    batch_size=1,
+    key=key,
+    post_ask=[plot_bo_iteration],
+    post_tell=[],
+)
+
+results = dm.run(
+    6,
+    black_box_function_evaluator=function_evaluator,
+)
+
+# %% [markdown]
+# We can see that our `DecisionMaker` is successfully able to find the minimimizer of the
+# black box function!
+#
+#
+
+# %% [markdown]
+# ## Conclusions
+
+# %% [markdown]
+# In this notebook we have provided an introduction to the new `decision_making` module of
+# GPJax. We have demonstrated how one may use the abstractions provided by this module to
+# implement a Bayesian optimisation loop, and have also highlighted some of the
+# flexibility provided by the module. We hope that this module will provide a useful
+# framework for solving a wide range of sequential decision making problems, and that it
+# will be easy for users to extend the functionality provided by the module to suit their
+# needs!
+#
+# We should note that the `decision_making` module is still in its early stages, and so
+# whilst we hope to avoid making breaking changes to it, they may occur as the module
+# evolves and more advanced functionality is implemented. If people have any feedback or
+# features they would like to implement/see implemented, feel free to open an issue on the
+# [GPJax GitHub page](https://github.com/JaxGaussianProcesses/GPJax/issues).
+#
+
+# %% [markdown]
+# ## System Configuration
+
+# %%
+# %reload_ext watermark
+# %watermark -n -u -v -iv -w -a 'Thomas Christie'

--- a/gpjax/decision_making/__init__.py
+++ b/gpjax/decision_making/__init__.py
@@ -28,13 +28,16 @@ from gpjax.decision_making.test_functions import (
     Quadratic,
 )
 from gpjax.decision_making.utility_functions import (
+    AbstractSinglePointUtilityFunctionBuilder,
     AbstractUtilityFunctionBuilder,
+    SinglePointUtilityFunction,
     ThompsonSampling,
     UtilityFunction,
 )
 from gpjax.decision_making.utility_maximizer import (
+    AbstractSinglePointUtilityMaximizer,
     AbstractUtilityMaximizer,
-    ContinuousUtilityMaximizer,
+    ContinuousSinglePointUtilityMaximizer,
 )
 from gpjax.decision_making.utils import build_function_evaluator
 
@@ -43,9 +46,11 @@ __all__ = [
     "AbstractUtilityMaximizer",
     "AbstractDecisionMaker",
     "AbstractSearchSpace",
+    "AbstractSinglePointUtilityFunctionBuilder",
+    "AbstractSinglePointUtilityMaximizer",
     "UtilityFunction",
     "build_function_evaluator",
-    "ContinuousUtilityMaximizer",
+    "ContinuousSinglePointUtilityMaximizer",
     "ContinuousSearchSpace",
     "UtilityDrivenDecisionMaker",
     "AbstractContinuousTestFunction",
@@ -53,5 +58,6 @@ __all__ = [
     "LogarithmicGoldsteinPrice",
     "PosteriorHandler",
     "Quadratic",
+    "SinglePointUtilityFunction",
     "ThompsonSampling",
 ]

--- a/gpjax/decision_making/decision_maker.py
+++ b/gpjax/decision_making/decision_maker.py
@@ -274,6 +274,8 @@ class UtilityDrivenDecisionMaker(AbstractDecisionMaker):
         """
         self.current_utility_functions = []
         maximizers = []
+        # We currently only allow Thompson sampling to be run with batch size > 1. More
+        # batched utility functions may be added in the future.
         if isinstance(self.utility_function_builder, ThompsonSampling) or (
             (not isinstance(self.utility_function_builder, ThompsonSampling))
             and (self.batch_size == 1)

--- a/gpjax/decision_making/utility_functions/__init__.py
+++ b/gpjax/decision_making/utility_functions/__init__.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 from gpjax.decision_making.utility_functions.base import (
+    AbstractSinglePointUtilityFunctionBuilder,
     AbstractUtilityFunctionBuilder,
+    SinglePointUtilityFunction,
     UtilityFunction,
 )
 from gpjax.decision_making.utility_functions.thompson_sampling import ThompsonSampling
@@ -21,5 +23,7 @@ from gpjax.decision_making.utility_functions.thompson_sampling import ThompsonSa
 __all__ = [
     "UtilityFunction",
     "AbstractUtilityFunctionBuilder",
+    "AbstractSinglePointUtilityFunctionBuilder",
+    "SinglePointUtilityFunction",
     "ThompsonSampling",
 ]

--- a/gpjax/decision_making/utility_functions/base.py
+++ b/gpjax/decision_making/utility_functions/base.py
@@ -32,17 +32,27 @@ from gpjax.typing import (
     KeyArray,
 )
 
-UtilityFunction = Callable[[Float[Array, "N D"]], Float[Array, "N 1"]]
+SinglePointUtilityFunction = Callable[[Float[Array, "N D"]], Float[Array, "N 1"]]
 """
-Type alias for utility functions, which take an array of points of shape $`[N, D]`$
+Type alias for utility functions which don't support batching, and instead characterise
+the utility of querying a single point, rather than a batch of points. They take an array of points of shape $`[N, D]`$
 and return the value of the utility function at each point in an array of shape $`[N, 1]`$.
 """
 
 
+UtilityFunction = SinglePointUtilityFunction
+"""
+Type alias for all utility functions. Currently we only support
+`SinglePointUtilityFunction`s, but in future may support batched utility functions too.
+Note that `UtilityFunction`s are *maximised* in order to decide which point, or batch of points, to query next.
+"""
+
+
 @dataclass
-class AbstractUtilityFunctionBuilder(ABC):
+class AbstractSinglePointUtilityFunctionBuilder(ABC):
     """
-    Abstract class for building utility functions.
+    Abstract class for building utility functions which don't support batches. As such,
+    they characterise the utility of querying a single point next.
     """
 
     def check_objective_present(
@@ -75,7 +85,7 @@ class AbstractUtilityFunctionBuilder(ABC):
         posteriors: Mapping[str, AbstractPosterior],
         datasets: Mapping[str, Dataset],
         key: KeyArray,
-    ) -> UtilityFunction:
+    ) -> SinglePointUtilityFunction:
         """
         Build a `UtilityFunction` from a set of posteriors and datasets.
 
@@ -87,7 +97,14 @@ class AbstractUtilityFunctionBuilder(ABC):
             key (KeyArray): JAX PRNG key used for random number generation.
 
         Returns:
-            UtilityFunction: Utility function to be *maximised* in order to
+            SinglePointUtilityFunction: Utility function to be *maximised* in order to
             decide which point to query next.
         """
         raise NotImplementedError
+
+
+AbstractUtilityFunctionBuilder = AbstractSinglePointUtilityFunctionBuilder
+"""
+Type alias for utility function builders. For now this only include single point utility
+function builders, but in the future we may support batched utility function builders.
+"""

--- a/gpjax/decision_making/utility_maximizer.py
+++ b/gpjax/decision_making/utility_maximizer.py
@@ -26,7 +26,7 @@ from gpjax.decision_making.search_space import (
     AbstractSearchSpace,
     ContinuousSearchSpace,
 )
-from gpjax.decision_making.utility_functions import UtilityFunction
+from gpjax.decision_making.utility_functions import SinglePointUtilityFunction
 from gpjax.typing import (
     Array,
     Float,
@@ -36,14 +36,15 @@ from gpjax.typing import (
 
 
 def _get_discrete_maximizer(
-    query_points: Float[Array, "N D"], utility_function: UtilityFunction
+    query_points: Float[Array, "N D"], utility_function: SinglePointUtilityFunction
 ) -> Float[Array, "1 D"]:
     """Get the point which maximises the utility function evaluated at a given set of points.
 
     Args:
         query_points (Float[Array, "N D"]): Set of points at which to evaluate the
         utility function.
-        utility_function (UtilityFunction): Utility function to evaluate at `query_points`.
+        utility_function (SinglePointUtilityFunction): Single point utility function to
+        be evaluated at "query_points".
 
     Returns:
         Float[Array, "1 D"]: Point in `query_points` which maximises the utility function.
@@ -59,13 +60,13 @@ def _get_discrete_maximizer(
 
 
 @dataclass
-class AbstractUtilityMaximizer(ABC):
-    """Abstract base class for utility function maximizers."""
+class AbstractSinglePointUtilityMaximizer(ABC):
+    """Abstract base class for single point utility function maximizers."""
 
     @abstractmethod
     def maximize(
         self,
-        utility_function: UtilityFunction,
+        utility_function: SinglePointUtilityFunction,
         search_space: AbstractSearchSpace,
         key: KeyArray,
     ) -> Float[Array, "1 D"]:
@@ -85,7 +86,7 @@ class AbstractUtilityMaximizer(ABC):
 
 
 @dataclass
-class ContinuousUtilityMaximizer(AbstractUtilityMaximizer):
+class ContinuousSinglePointUtilityMaximizer(AbstractSinglePointUtilityMaximizer):
     """The `ContinuousUtilityMaximizer` class is used to maximize utility
     functions over the continuous domain with L-BFGS-B. First we sample the utility
     function at `num_initial_samples` points from the search space, and then we run
@@ -109,7 +110,7 @@ class ContinuousUtilityMaximizer(AbstractUtilityMaximizer):
 
     def maximize(
         self,
-        utility_function: UtilityFunction,
+        utility_function: SinglePointUtilityFunction,
         search_space: ContinuousSearchSpace,
         key: KeyArray,
     ) -> Float[Array, "1 D"]:
@@ -150,3 +151,10 @@ class ContinuousUtilityMaximizer(AbstractUtilityMaximizer):
                 max_observed_utility_function_value = optimized_utility_function_value
                 maximizer = optimized_point
         return maximizer
+
+
+AbstractUtilityMaximizer = AbstractSinglePointUtilityMaximizer
+"""
+Type alias for a utility maximizer. Currently we only support single point utility
+functions, but in future may support batched utility functions.
+"""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
     - Stochastic sparse GPs: examples/collapsed_vi.py
     - Pathwise Sampling for Spatial Modelling: examples/spatial.py
     - Bayesian Optimisation: examples/bayesian_optimisation.py
+    - Decision Making: examples/decision_making.py
   - 📖 Guides for customisation:
     - Kernels: examples/constructing_new_kernels.py
     - Likelihoods: examples/likelihoods_guide.py

--- a/tests/test_decision_making/test_utility_maximizer.py
+++ b/tests/test_decision_making/test_utility_maximizer.py
@@ -27,16 +27,16 @@ from gpjax.decision_making.test_functions.continuous_functions import (
     Quadratic,
 )
 from gpjax.decision_making.utility_maximizer import (
-    AbstractUtilityMaximizer,
-    ContinuousUtilityMaximizer,
+    AbstractSinglePointUtilityMaximizer,
+    ContinuousSinglePointUtilityMaximizer,
     _get_discrete_maximizer,
 )
 from gpjax.typing import KeyArray
 
 
-def test_abstract_utility_maximizer():
+def test_abstract_single_batch_utility_maximizer():
     with pytest.raises(TypeError):
-        AbstractUtilityMaximizer()
+        AbstractSinglePointUtilityMaximizer()
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ def test_continuous_maximizer_raises_error_with_erroneous_num_initial_samples(
     num_initial_samples: int,
 ):
     with pytest.raises(ValueError):
-        ContinuousUtilityMaximizer(
+        ContinuousSinglePointUtilityMaximizer(
             num_initial_samples=num_initial_samples, num_restarts=1
         )
 
@@ -77,7 +77,9 @@ def test_continuous_maximizer_raises_error_with_erroneous_num_restarts(
     num_restarts: int,
 ):
     with pytest.raises(ValueError):
-        ContinuousUtilityMaximizer(num_initial_samples=1, num_restarts=num_restarts)
+        ContinuousSinglePointUtilityMaximizer(
+            num_initial_samples=1, num_restarts=num_restarts
+        )
 
 
 @pytest.mark.parametrize(
@@ -95,10 +97,10 @@ def test_continous_maximizer_returns_same_point_with_same_key(
     key: KeyArray,
     num_restarts: int,
 ):
-    continuous_maximizer_one = ContinuousUtilityMaximizer(
+    continuous_maximizer_one = ContinuousSinglePointUtilityMaximizer(
         num_initial_samples=1000, num_restarts=num_restarts
     )
-    continuous_maximizer_two = ContinuousUtilityMaximizer(
+    continuous_maximizer_two = ContinuousSinglePointUtilityMaximizer(
         num_initial_samples=1000, num_restarts=num_restarts
     )
     utility_function = lambda x: -1.0 * test_function.evaluate(x)
@@ -137,7 +139,7 @@ def test_continuous_maximizer_finds_correct_point(
     key: KeyArray,
     num_restarts: int,
 ):
-    continuous_utility_maximizer = ContinuousUtilityMaximizer(
+    continuous_utility_maximizer = ContinuousSinglePointUtilityMaximizer(
         num_initial_samples=1000, num_restarts=num_restarts
     )
     utility_function = lambda x: -1.0 * test_function.evaluate(x)
@@ -159,7 +161,7 @@ def test_continuous_maximizer_finds_correct_point(
 )  # Sampling with tfp causes JAX to raise a UserWarning due to some internal logic around jnp.argsort
 def test_continuous_maximizer_jaxopt_component(key: KeyArray, num_restarts: int):
     quadratic = Quadratic()
-    continuous_utility_maximizer = ContinuousUtilityMaximizer(
+    continuous_utility_maximizer = ContinuousSinglePointUtilityMaximizer(
         num_initial_samples=1,  # Force JaxOpt L-GFBS-B to do the heavy lifting
         num_restarts=num_restarts,
     )

--- a/tests/test_decision_making/utils.py
+++ b/tests/test_decision_making/utils.py
@@ -18,19 +18,21 @@ from beartype.typing import Mapping
 from gpjax.dataset import Dataset
 from gpjax.decision_making.test_functions import Quadratic
 from gpjax.decision_making.utility_functions import (
-    AbstractUtilityFunctionBuilder,
-    UtilityFunction,
+    AbstractSinglePointUtilityFunctionBuilder,
+    SinglePointUtilityFunction,
 )
 from gpjax.gps import ConjugatePosterior
 from gpjax.typing import KeyArray
 
 
-class QuadraticUtilityFunctionBuilder(AbstractUtilityFunctionBuilder):
+class QuadraticSinglePointUtilityFunctionBuilder(
+    AbstractSinglePointUtilityFunctionBuilder
+):
     """
     Dummy utility function builder for testing purposes, which returns the negative
     of the value of a quadratic test function at the input points. This is because
     utility functions are *maximised*, and we wish to *minimise* the quadratic test
-    function.
+    function. Note that this is a `SinglePointUtilityFunctionBuilder`.
     """
 
     def build_utility_function(
@@ -38,7 +40,7 @@ class QuadraticUtilityFunctionBuilder(AbstractUtilityFunctionBuilder):
         posteriors: Mapping[str, ConjugatePosterior],
         datasets: Mapping[str, Dataset],
         key: KeyArray,
-    ) -> UtilityFunction:
+    ) -> SinglePointUtilityFunction:
         test_function = Quadratic()
         return lambda x: -1.0 * test_function.evaluate(
             x


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [X] I've added tests for new code.
- [X] I've added docstrings for the new code.

## Description

In the future certain utility functions will be "batched" utility functions which quantify the utility of querying a *batch* of points rather than a single point. These utility functions may in turn be optimised differently.

Therefore, I propose we have a `SinglePointUtilityFunction` type for non-batched utility functions, which has type annotation `[N  D] -> [N 1]`, and in the future we may add `BatchUtilityFunction` which has type  annotation `[N B D] -> [N 1]`. Distinguishing between these makes it easy for users to see which utility functions support batching.

Also refactored UtilityDrivenDecisionMaker to enable for Thompson sampling to be used in a batched context, and updated unit tests to reflect this. Finally, added a new notebook to serve as an introduction to the `decision_making` module.

Issue Number: N/A
