### PR TITLE
[WIP]: minimal general matern kernel.

### DIFF
--- a/gpjax/kernels/__init__.py
+++ b/gpjax/kernels/__init__.py
@@ -39,6 +39,7 @@ from gpjax.kernels.nonstationary import (
 )
 from gpjax.kernels.stationary import (
     RBF,
+    Matern,
     Matern12,
     Matern32,
     Matern52,
@@ -55,6 +56,7 @@ __all__ = [
     "RBF",
     "GraphKernel",
     "CatKernel",
+    "Matern",
     "Matern12",
     "Matern32",
     "Matern52",

--- a/gpjax/kernels/stationary/__init__.py
+++ b/gpjax/kernels/stationary/__init__.py
@@ -16,6 +16,7 @@
 from gpjax.kernels.stationary.matern12 import Matern12
 from gpjax.kernels.stationary.matern32 import Matern32
 from gpjax.kernels.stationary.matern52 import Matern52
+from gpjax.kernels.stationary.matern import Matern
 from gpjax.kernels.stationary.periodic import Periodic
 from gpjax.kernels.stationary.powered_exponential import PoweredExponential
 from gpjax.kernels.stationary.rational_quadratic import RationalQuadratic
@@ -26,6 +27,7 @@ __all__ = [
     "Matern12",
     "Matern32",
     "Matern52",
+    "Matern",
     "Periodic",
     "PoweredExponential",
     "RationalQuadratic",

--- a/gpjax/kernels/stationary/matern.py
+++ b/gpjax/kernels/stationary/matern.py
@@ -1,0 +1,91 @@
+# Copyright 2023 The JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from dataclasses import dataclass
+
+from beartype.typing import Union
+import jax.numpy as jnp
+import jax.scipy as jsp
+from jaxtyping import Float
+from logbesselk.jax import log_bessel_k as log_kv
+import tensorflow_probability.substrates.jax.bijectors as tfb
+import tensorflow_probability.substrates.jax.distributions as tfd
+
+from gpjax.base import param_field
+from gpjax.kernels.base import AbstractKernel
+from gpjax.kernels.stationary.utils import (
+    build_student_t_distribution,
+    euclidean_distance,
+)
+from gpjax.typing import (
+    Array,
+    ScalarFloat,
+)
+
+
+@dataclass
+class Matern(AbstractKernel):
+    r"""The Matérn kernel with general smoothness parameter If you use smoothness 1/2, 3/2, 5/2, please use the corresponding Matern12, Matern32, Matern52 kernel for better efficiency.
+
+    Or for smoothness approaching infinity, please use the RBF kernel.
+
+    """
+
+    smoothness: ScalarFloat = param_field(jnp.array(1.0), bijector=tfb.Softplus())
+    lengthscale: Union[ScalarFloat, Float[Array, " D"]] = param_field(
+        jnp.array(1.0), bijector=tfb.Softplus()
+    )
+    variance: ScalarFloat = param_field(jnp.array(1.0), bijector=tfb.Softplus())
+    name: str = "Matérn"
+
+    def __call__(
+        self,
+        x: Float[Array, " D"],
+        y: Float[Array, " D"],
+    ) -> ScalarFloat:
+        r"""Compute the Matérn 3/2 kernel between a pair of arrays.
+
+        Evaluate the kernel on a pair of inputs $`(x, y)`$ with
+        lengthscale parameter $`\ell`$ and variance $`\sigma^2`$.
+
+        ```math
+            k(x, y) = \sigma^2 \exp \Bigg(1+ \frac{\sqrt{3}\lvert x-y \rvert}{\ell^2}  \Bigg)\exp\Bigg(-\frac{\sqrt{3}\lvert x-y\rvert}{\ell^2} \Bigg)
+        ```
+
+        Args:
+            x (Float[Array, " D"]): The left hand argument of the kernel function's call.
+            y (Float[Array, " D"]): The right hand argument of the kernel function's call.
+
+        Returns
+        -------
+            ScalarFloat: The value of $k(x, y)$.
+        """
+        nu = self.smoothness
+        x = self.slice_input(x) / self.lengthscale
+        y = self.slice_input(y) / self.lengthscale
+        tau = euclidean_distance(x, y)
+        weighted_distance = jnp.sqrt(2.0 * nu) * tau
+        normalising_constant = (2.0 ** (1.0 - nu)) / jsp.special.gamma(nu)
+        K = (
+            self.variance
+            * normalising_constant
+            * (weighted_distance**nu)
+            * jnp.exp(log_kv(nu, weighted_distance))
+        )
+        return K.squeeze()
+
+    @property
+    def spectral_density(self) -> tfd.Distribution:
+        return build_student_t_distribution(nu=2.0 * self.smoothness)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2265,6 +2265,18 @@ doc = ["myst-parser", "sphinx", "sphinx-book-theme"]
 test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
+name = "logbesselk"
+version = "3.2.0"
+description = "Provide function to calculate the modified Bessel function of the second kind"
+category = "main"
+optional = false
+python-versions = ">=3.8,<3.12"
+files = [
+    {file = "logbesselk-3.2.0-py3-none-any.whl", hash = "sha256:ffb58a6d8c738722666fa0522ad4583ec9f5862a7e0882df6fecc6df988468bc"},
+    {file = "logbesselk-3.2.0.tar.gz", hash = "sha256:886b7eeb04dd906a5872400a1b0ab18cefb416a3b082f167e0d4033c8feb4313"},
+]
+
+[[package]]
 name = "lxml"
 version = "4.9.3"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
@@ -5830,4 +5842,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "5579512ea30793a8d3ea7fe9e486e2635226caa0bf5415b173f650751c8b3016"
+content-hash = "6d1b63822ef4793b66c49caaf979816d3513ffc82a245fe680d74922edf04f01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ jax = ">=0.4.10"
 jaxlib = ">=0.4.10"
 orbax-checkpoint = ">=0.2.3"
 cola-ml = "^0.0.1"
+logbesselk = "^3.2.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.2.2"


### PR DESCRIPTION
@astfalckl would be great to get your thoughts on this. If we could get a simple example showing where the general Matern offers that greater spectral flexibility - that would be excellent.

## Type of changes

- [ ] Bug fix
- [ x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

This adds a Matérn kernel for general smoothness parameter. #391 

## TODO:
- Needs testing, and check for consistency with our Matern12, Matern32, Matern52 kernels.
- Performance is slow. While we know this will be slower, how much slower should this be?
- Update docstrings and provide the general matern formula (currently this has just robbed the docstring from one of the other integer Materns).
- Perhaps document on an example where this important - i.e., show a nice `spectral_density` example.
- Why are we passing `nu = 2 * nu` in the spectral density for the Matern12, Matern32, Matern52 kernels this seems rather weird (I mimic this for my implementation)? Also why do we not define the spectral density with the lengthscale and variance? Instead these terms seem to appear in basis function computation - I would expect to get the spectral density of my Kernel for my given variance and lengthscale if I called `spectral_density`? @thomaspinder 
