### PR TITLE
feat(gpjax/kernels/base.py): add diagonal

### DIFF
--- a/gpjax/kernels/base.py
+++ b/gpjax/kernels/base.py
@@ -63,6 +63,9 @@ class AbstractKernel(Module):
     def gram(self, x: Num[Array, "N D"]):
         return self.compute_engine.gram(self, x)
 
+    def diagonal(self, x: Num[Array, "N D"]):
+        return self.compute_engine.diagonal(self, x)
+
     def slice_input(self, x: Float[Array, "... D"]) -> Float[Array, "... Q"]:
         r"""Slice out the relevant columns of the input matrix.
 

--- a/gpjax/kernels/computations/basis_functions.py
+++ b/gpjax/kernels/computations/basis_functions.py
@@ -12,6 +12,7 @@ Kernel = tp.TypeVar("Kernel", bound="gpjax.kernels.base.AbstractKernel")  # noqa
 from cola import PSD
 from cola.ops import (
     Dense,
+    Diagonal,
     LinearOperator,
 )
 
@@ -57,6 +58,20 @@ class BasisFunctionComputation(AbstractKernelComputation):
         """
         z1 = self.compute_features(kernel, inputs)
         return PSD(Dense(self.scaling(kernel) * jnp.matmul(z1, z1.T)))
+
+    def diagonal(self, kernel: Kernel, inputs: Float[Array, "N D"]) -> Diagonal:
+        r"""For a given kernel, compute the elementwise diagonal of the
+        NxN gram matrix on an input matrix of shape NxD.
+
+        Args:
+            kernel (AbstractKernel): the kernel function.
+            inputs (Float[Array, "N D"]): The input matrix.
+
+        Returns
+        -------
+            Diagonal: The computed diagonal variance entries.
+        """
+        return super().diagonal(kernel.base_kernel, inputs)
 
     def compute_features(
         self, kernel: Kernel, x: Float[Array, "N D"]

--- a/tests/test_kernels/test_nonstationary.py
+++ b/tests/test_kernels/test_nonstationary.py
@@ -241,4 +241,4 @@ class TestArcCosine(BaseTestKernel):
         integrands = H_a * H_b * (weights_a**order) * (weights_b**order)
         Kab_approx = 2.0 * jnp.mean(integrands)
 
-        assert jnp.max(Kab_approx - Kab_exact) < 1e-4
+        assert jnp.max(jnp.abs(Kab_approx - Kab_exact)) < 1e-4

--- a/tests/test_kernels/test_nonstationary.py
+++ b/tests/test_kernels/test_nonstationary.py
@@ -16,7 +16,10 @@ from dataclasses import is_dataclass
 from itertools import product
 from typing import List
 
-from cola.ops import LinearOperator
+from cola.ops import (
+    Diagonal,
+    LinearOperator,
+)
 import jax
 from jax import config
 import jax.numpy as jnp
@@ -128,6 +131,21 @@ class BaseTestKernel:
         assert isinstance(Kxx, LinearOperator)
         assert Kxx.shape == (n, n)
         assert jnp.all(jnp.linalg.eigvalsh(Kxx.to_dense() + jnp.eye(n) * 1e-6) > 0.0)
+
+    @pytest.mark.parametrize("n", [1, 2, 5], ids=lambda x: f"n={x}")
+    @pytest.mark.parametrize("dim", [1, 3], ids=lambda x: f"dim={x}")
+    def test_diagonal(self, dim: int, n: int) -> None:
+        # Initialise kernel
+        kernel: AbstractKernel = self.kernel()
+
+        # Inputs
+        x = jnp.linspace(0.0, 1.0, n * dim).reshape(n, dim)
+
+        # Test diagonal
+        Kxx = kernel.diagonal(x)
+        assert isinstance(Kxx, Diagonal)
+        assert Kxx.shape == (n, n)
+        assert jnp.all(Kxx.diag + 1e-6 > 0.0)
 
     @pytest.mark.parametrize("n_a", [1, 2, 5], ids=lambda x: f"n_a={x}")
     @pytest.mark.parametrize("n_b", [1, 2, 5], ids=lambda x: f"n_b={x}")

--- a/tests/test_kernels/test_nonstationary.py
+++ b/tests/test_kernels/test_nonstationary.py
@@ -128,9 +128,11 @@ class BaseTestKernel:
 
         # Test gram matrix
         Kxx = kernel.gram(x)
+        Kxx_cross = kernel.cross_covariance(x, x)
         assert isinstance(Kxx, LinearOperator)
         assert Kxx.shape == (n, n)
         assert jnp.all(jnp.linalg.eigvalsh(Kxx.to_dense() + jnp.eye(n) * 1e-6) > 0.0)
+        assert jnp.allclose(Kxx_cross, Kxx.to_dense())
 
     @pytest.mark.parametrize("n", [1, 2, 5], ids=lambda x: f"n={x}")
     @pytest.mark.parametrize("dim", [1, 3], ids=lambda x: f"dim={x}")
@@ -143,9 +145,11 @@ class BaseTestKernel:
 
         # Test diagonal
         Kxx = kernel.diagonal(x)
+        Kxx_gram = jnp.diagonal(kernel.gram(x).to_dense())
         assert isinstance(Kxx, Diagonal)
         assert Kxx.shape == (n, n)
         assert jnp.all(Kxx.diag + 1e-6 > 0.0)
+        assert jnp.allclose(Kxx_gram, Kxx.diag)
 
     @pytest.mark.parametrize("n_a", [1, 2, 5], ids=lambda x: f"n_a={x}")
     @pytest.mark.parametrize("n_b", [1, 2, 5], ids=lambda x: f"n_b={x}")
@@ -157,11 +161,14 @@ class BaseTestKernel:
         # Inputs
         a = jnp.linspace(-1.0, 1.0, n_a * dim).reshape(n_a, dim)
         b = jnp.linspace(3.0, 4.0, n_b * dim).reshape(n_b, dim)
+        c = jnp.vstack((a, b))
 
         # Test cross-covariance
         Kab = kernel.cross_covariance(a, b)
+        Kab_gram = kernel.gram(c).to_dense()[:n_a, n_a:]
         assert isinstance(Kab, jnp.ndarray)
         assert Kab.shape == (n_a, n_b)
+        assert jnp.allclose(Kab, Kab_gram)
 
 
 def prod(inp):

--- a/tests/test_kernels/test_stationary.py
+++ b/tests/test_kernels/test_stationary.py
@@ -17,7 +17,10 @@
 from dataclasses import is_dataclass
 from itertools import product
 
-from cola.ops import LinearOperator
+from cola.ops import (
+    Diagonal,
+    LinearOperator,
+)
 import jax
 from jax import config
 import jax.numpy as jnp
@@ -132,6 +135,21 @@ class BaseTestKernel:
         assert isinstance(Kxx, LinearOperator)
         assert Kxx.shape == (n, n)
         assert jnp.all(jnp.linalg.eigvalsh(Kxx.to_dense() + jnp.eye(n) * 1e-6) > 0.0)
+
+    @pytest.mark.parametrize("n", [1, 2, 5], ids=lambda x: f"n={x}")
+    @pytest.mark.parametrize("dim", [1, 3], ids=lambda x: f"dim={x}")
+    def test_diagonal(self, dim: int, n: int) -> None:
+        # Initialise kernel
+        kernel: AbstractKernel = self.kernel()
+
+        # Inputs
+        x = jnp.linspace(0.0, 1.0, n * dim).reshape(n, dim)
+
+        # Test diagonal
+        Kxx = kernel.diagonal(x)
+        assert isinstance(Kxx, Diagonal)
+        assert Kxx.shape == (n, n)
+        assert jnp.all(Kxx.diag + 1e-6 > 0.0)
 
     @pytest.mark.parametrize("n_a", [1, 2, 5], ids=lambda x: f"n_a={x}")
     @pytest.mark.parametrize("n_b", [1, 2, 5], ids=lambda x: f"n_b={x}")


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

`AbstractKernel` has wrappers for `cross_covariance` and `gram` but not for `diagonal`, when all three are defined by `AbstractKernelComputation` (`diagonal` is actually concretely implemented by `AbstractKernelComputation`). 

This PR adds `diagonal` to `AbstractKernel`. 

Although the change is trivial, I believe it's important for the following reasons.

Currently, the way to get the diagonal of a kernel matrix efficiently would be code like

```python
import jax.numpy as jnp
from gpjax.kernels import DenseKernelComputation, Matern52

kernel = Matern52()
diagonal = DenseKernelComputation().diagonal
# diag([1. 1. 1. 1. 1. 1. 1. 1. 1. 1.])
print(diagonal(kernel, jnp.zeros((10, 3))))
```

Other than being needlessly verbose, this obscures the fact that most of the `*Computation` classes (`DiagonalKernelComputation`, etc.) could be used in place of `DenseKernelComputation` without changing the underlying implementation from `AbstractKernelComputation`. Instead, code like

```python
kernel.diagonal(jnp.zeros((10, 3)))
```

is cleaner and would allow specific kernels to provide a more efficient, specialized implementation (for example, the Matern family has a unit diagonal no matter the input data).