### PR TITLE
test(test_gps.py): fix jaxtyping.TypeCheckError

### DIFF
--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -15,8 +15,13 @@
 
 try:
     import beartype
+    import jaxtyping
 
-    ValidationErrors = (ValueError, beartype.roar.BeartypeCallHintParamViolation)
+    ValidationErrors = (
+        ValueError,
+        beartype.roar.BeartypeCallHintParamViolation,
+        jaxtyping.TypeCheckError,
+    )
 except ImportError:
     ValidationErrors = ValueError
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [ ] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

My pytest header is as follows.
```text
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.4.0
rootdir: ...
configfile: pyproject.toml
plugins: jaxtyping-0.2.25, typeguard-4.1.5
```

Running `pytest tests/test_gps.py` gives

```text
============================================================================== short test summary info ===============================================================================
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function0-RBF-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function0-RBF-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function0-Matern52-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function0-Matern52-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function1-RBF-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function1-RBF-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function1-Matern52-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_prior_sample_approx[mean_function1-Matern52-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function0-RBF-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function0-RBF-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function0-Matern52-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function0-Matern52-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function1-RBF-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function1-RBF-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function1-Matern52-1] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
FAILED tests/test_gps.py::test_conjugate_posterior_sample_approx[mean_function1-Matern52-5] - jaxtyping.TypeCheckError: Type-check error whilst checking the parameters of sample_approx.
=========================================================================== 16 failed, 42 passed in 3.83s ============================================================================
```

This patch fixes the test by ignoring the warnings from `jaxtyping` like how `beartype` is already ignored.

This could be a consequence of my (updated) dependencies since the test passes on CI.

P.S. `flax` is declared as a `dev` and `docs` dependency but it's used in the [tests](https://github.com/JaxGaussianProcesses/GPJax/blob/07d99dbd64f62e414152709aac8850d8bc3a844e/tests/test_base/test_module.py#L28) so it should be also added to `test`.