### PR TITLE
Fixed mutable default value error in VelocityKernel and HelmholtzKernel dataclasses in python 3.11

### DIFF
--- a/docs/examples/oceanmodelling.py
+++ b/docs/examples/oceanmodelling.py
@@ -195,10 +195,17 @@ dataset_ground_truth = dataset_3d(pos_test, vel_test)
 
 
 # %%
+from dataclasses import field
+
+
 @dataclass
 class VelocityKernel(gpx.kernels.AbstractKernel):
-    kernel0: gpx.kernels.AbstractKernel = gpx.kernels.RBF(active_dims=[0, 1])
-    kernel1: gpx.kernels.AbstractKernel = gpx.kernels.RBF(active_dims=[0, 1])
+    kernel0: gpx.kernels.AbstractKernel = field(
+        default_factory=lambda: gpx.kernels.RBF(active_dims=[0, 1])
+    )
+    kernel1: gpx.kernels.AbstractKernel = field(
+        default_factory=lambda: gpx.kernels.RBF(active_dims=[0, 1])
+    )
 
     def __call__(
         self, X: Float[Array, "1 D"], Xp: Float[Array, "1 D"]
@@ -429,8 +436,12 @@ plot_fields(dataset_ground_truth, dataset_train, dataset_latent_velocity)
 @dataclass
 class HelmholtzKernel(gpx.kernels.AbstractKernel):
     # initialise Phi and Psi kernels as any stationary kernel in gpJax
-    potential_kernel: gpx.kernels.AbstractKernel = gpx.kernels.RBF(active_dims=[0, 1])
-    stream_kernel: gpx.kernels.AbstractKernel = gpx.kernels.RBF(active_dims=[0, 1])
+    potential_kernel: gpx.kernels.AbstractKernel = field(
+        default_factory=lambda: gpx.kernels.RBF(active_dims=[0, 1])
+    )
+    stream_kernel: gpx.kernels.AbstractKernel = field(
+        default_factory=lambda: gpx.kernels.RBF(active_dims=[0, 1])
+    )
 
     def __call__(
         self, X: Float[Array, "1 D"], Xp: Float[Array, "1 D"]

--- a/docs/examples/oceanmodelling.py
+++ b/docs/examples/oceanmodelling.py
@@ -10,7 +10,7 @@
 from jax import config
 
 config.update("jax_enable_x64", True)
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from jax import hessian
 from jax import config
@@ -195,7 +195,6 @@ dataset_ground_truth = dataset_3d(pos_test, vel_test)
 
 
 # %%
-from dataclasses import field
 
 
 @dataclass


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've formatted the new code by running `poetry run pre-commit run --all-files --show-diff-on-failure` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

Oceanmodelling example notebook wasn't working in python 3.11 or 3.12:

ValueError: mutable default <class 'gpjax.kernels.stationary.rbf.RBF'> for field kernel0 is not allowed: use default_factory
Fixed this issue by replacing direct assignment of kernels with field(default_factory=...). Although checked backwards compatibility with python 3.10

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Issue Number: N/A
