### PR TITLE
optional solver_algorithm parameter to sample_approx

### DIFF
--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -40,7 +40,7 @@ __license__ = "MIT"
 __description__ = "Didactic Gaussian processes in JAX"
 __url__ = "https://github.com/JaxGaussianProcesses/GPJax"
 __contributors__ = "https://github.com/JaxGaussianProcesses/GPJax/graphs/contributors"
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 __all__ = [
     "base",

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -25,7 +25,6 @@ from typing import (
     Type,
 )
 
-# from gpjax.dataset import Dataset
 from cola.linalg.algorithm_base import Auto
 from cola.linalg.decompositions.decompositions import Cholesky
 from cola.linalg.inverse.cg import CG


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `hatch run dev:format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

- Added an optional solver_algorithm parameter to the `ConjugatePosterior.sample_approx` method for solving the inverse of the covariance matrix.
- Updated the `test_conjugate_posterior_sample_approx` test function to include the `solver_algorithm` parameter.

Issue Number: #475. Related issue https://github.com/JaxGaussianProcesses/GPJax/issues/381.
