### PR TITLE
Fix `Static` check in `Gaussian` likelihood

### DIFF
--- a/examples/intro_to_kernels.py
+++ b/examples/intro_to_kernels.py
@@ -246,7 +246,7 @@ kernel = gpx.kernels.Matern52(
 prior = gpx.gps.Prior(mean_function=mean, kernel=kernel)
 
 likelihood = gpx.likelihoods.Gaussian(
-    num_datapoints=D.n, obs_stddev=PositiveReal(value=jnp.array(1e-3), tag="Static")
+    num_datapoints=D.n, obs_stdev=Static(jnp.array(1e-3))
 )  # Our function is noise-free, so we set the observation noise's standard deviation to a very small value
 
 no_opt_posterior = prior * likelihood

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -28,7 +28,6 @@ from gpjax.integrators import (
     GHQuadratureIntegrator,
 )
 from gpjax.parameters import (
-    Parameter,
     PositiveReal,
     Static,
 )
@@ -152,10 +151,9 @@ class Gaussian(AbstractLikelihood):
                 likelihoods. Must be an instance of `AbstractIntegrator`. For the Gaussian likelihood, this defaults to
                 the `AnalyticalGaussianIntegrator`, as the expected log likelihood can be computed analytically.
         """
-        if isinstance(obs_stddev, Parameter):
-            self.obs_stddev = obs_stddev
-        else:
-            self.obs_stddev = PositiveReal(jnp.asarray(obs_stddev))
+        if not isinstance(obs_stddev, (PositiveReal, Static)):
+            obs_stddev = PositiveReal(jnp.asarray(obs_stddev))
+        self.obs_stddev = obs_stddev
 
         super().__init__(num_datapoints, integrator)
 


### PR DESCRIPTION
## Checklist

- [ x  ] I've formatted the new code by running `hatch run dev:format` before committing.
- [ NA ] I've added tests for new code.
- [ NA ] I've added docstrings for the new code.

## Description

Previously, a `Static` object passed as the `obs_stddev` argument to the `Gaussian` likelihood would be wrapped in `PositiveReal` because `isinstance(Static, Parameter)` evaluates to `False`. This was affecting examples `intro_to_kernels.py` and `bayesian_optimisation.py`. This PR fixes it.

Issue Number: N/A
