### PR TITLE
Allow to pass trainable inducing inputs to AbstractVariationalGaussian

### DIFF
--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -108,10 +108,17 @@ class AbstractVariationalGaussian(AbstractVariationalFamily[L]):
     def __init__(
         self,
         posterior: AbstractPosterior[P, L],
-        inducing_inputs: Float[Array, "N D"],
+        inducing_inputs: tp.Union[
+            Float[Array, "N D"],
+            Real,
+            Static,
+        ],
         jitter: ScalarFloat = 1e-6,
     ):
-        self.inducing_inputs = Static(inducing_inputs)
+        if not isinstance(inducing_inputs, (Real, Static)):
+            inducing_inputs = Real(inducing_inputs)
+
+        self.inducing_inputs = inducing_inputs
         self.jitter = jitter
 
         super().__init__(posterior)


### PR DESCRIPTION
## Checklist

- [ x ] I've formatted the new code by running `hatch run dev:format` before committing.
- [ NA  ] I've added tests for new code.
- [ NA ] I've added docstrings for the new code.

## Description

As things stand, `AbstractVariationalGaussian` defaults to static `inducing_inputs` and making them trainable requires manual surgery. This PR enables passing trainable (i.e. `Real`) or fixed (i.e. `Static`) `inducing_inputs` to `AbstractVariationalGaussian`. When an array is passed as `inducing_inputs`, it is wrapped in `Real` by default, to mimic the default behaviour in other GP libraries.

I am happy to write unit tests if required.

Issue Number: N/A
