### PR TITLE
Swap collapsed_vi.md and uncollapsed_vi.md

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,8 @@ nav:
     - Barycentres: _examples/barycentres.md
     - Deep kernel learning: _examples/deep_kernels.md
     - Graph kernels: _examples/graph_kernels.md
-    - Sparse GPs: _examples/uncollapsed_vi.md
-    - Stochastic sparse GPs: _examples/collapsed_vi.md
+    - Sparse GPs: _examples/collapsed_vi.md
+    - Stochastic sparse GPs: _examples/uncollapsed_vi.md
     - Bayesian Optimisation: _examples/bayesian_optimisation.md
     - Decision Making: _examples/decision_making.md
     - Multi-output GPs for Ocean Modelling: _examples/oceanmodelling.md


### PR DESCRIPTION
## Checklist

- [ NA ] I've formatted the new code by running `hatch run dev:format` before committing.
- [ NA ] I've added tests for new code.
- [ NA ] I've added docstrings for the new code.

## Description

Previously, the collapsed and uncollapsed VI examples in the docs were swapped. This PR fixes it.

Issue Number: N/A
