### PR TITLE
fix: update links in documentation to use the correct path for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,23 +71,23 @@ helped to shape GPJax into the package it is today.
 
 ## Notebook examples
 
-> - [**Conjugate Inference**](https://docs.jaxgaussianprocesses.com/examples/regression/)
-> - [**Classification**](https://docs.jaxgaussianprocesses.com/examples/classification/)
-> - [**Sparse Variational Inference**](https://docs.jaxgaussianprocesses.com/examples/collapsed_vi/)
-> - [**Stochastic Variational Inference**](https://docs.jaxgaussianprocesses.com/examples/uncollapsed_vi/)
-> - [**Laplace Approximation**](https://docs.jaxgaussianprocesses.com/examples/classification/#laplace-approximation)
-> - [**Inference on Non-Euclidean Spaces**](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/#custom-kernel)
-> - [**Inference on Graphs**](https://docs.jaxgaussianprocesses.com/examples/graph_kernels/)
-> - [**Pathwise Sampling**](https://docs.jaxgaussianprocesses.com/examples/spatial/)
-> - [**Learning Gaussian Process Barycentres**](https://docs.jaxgaussianprocesses.com/examples/barycentres/)
-> - [**Deep Kernel Regression**](https://docs.jaxgaussianprocesses.com/examples/deep_kernels/)
-> - [**Poisson Regression**](https://docs.jaxgaussianprocesses.com/examples/poisson/)
-> - [**Bayesian Optimisation**](https://docs.jaxgaussianprocesses.com/examples/bayesian_optimisation/)
+> - [**Conjugate Inference**](https://docs.jaxgaussianprocesses.com/_examples/regression/)
+> - [**Classification**](https://docs.jaxgaussianprocesses.com/_examples/classification/)
+> - [**Sparse Variational Inference**](https://docs.jaxgaussianprocesses.com/_examples/collapsed_vi/)
+> - [**Stochastic Variational Inference**](https://docs.jaxgaussianprocesses.com/_examples/uncollapsed_vi/)
+> - [**Laplace Approximation**](https://docs.jaxgaussianprocesses.com/_examples/classification/#laplace-approximation)
+> - [**Inference on Non-Euclidean Spaces**](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/#custom-kernel)
+> - [**Inference on Graphs**](https://docs.jaxgaussianprocesses.com/_examples/graph_kernels/)
+> - [**Pathwise Sampling**](https://docs.jaxgaussianprocesses.com/_examples/spatial/)
+> - [**Learning Gaussian Process Barycentres**](https://docs.jaxgaussianprocesses.com/_examples/barycentres/)
+> - [**Deep Kernel Regression**](https://docs.jaxgaussianprocesses.com/_examples/deep_kernels/)
+> - [**Poisson Regression**](https://docs.jaxgaussianprocesses.com/_examples/poisson/)
+> - [**Bayesian Optimisation**](https://docs.jaxgaussianprocesses.com/_examples/bayesian_optimisation/)
 
 ## Guides for customisation
 >
-> - [**Custom kernels**](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/#custom-kernel)
-> - [**UCI regression**](https://docs.jaxgaussianprocesses.com/examples/yacht/)
+> - [**Custom kernels**](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/#custom-kernel)
+> - [**UCI regression**](https://docs.jaxgaussianprocesses.com/_examples/yacht/)
 
 ## Conversion between `.ipynb` and `.py`
 Above examples are stored in [examples](docs/examples) directory in the double

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,10 @@
-# Welcome to GPJax!
+# Welcome to GPJax
 
 GPJax is a didactic Gaussian process (GP) library in JAX, supporting GPU
 acceleration and just-in-time compilation. We seek to provide a flexible
 API to enable researchers to rapidly prototype and develop new ideas.
 
 ![Gaussian process posterior.](static/GP.svg)
-
 
 ## "Hello, GP!"
 
@@ -53,7 +52,7 @@ would write on paper, as shown below.
 !!! Begin
 
     Looking for a good place to start? Then why not begin with our [regression
-    notebook](https://docs.jaxgaussianprocesses.com/examples/regression/).
+    notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/).
 
 ## Citing GPJax
 

--- a/examples/backend.py
+++ b/examples/backend.py
@@ -122,7 +122,7 @@ print(constant_param._tag)
 # For most users, you will not need to worry about this as we provide a set of default
 # bijectors that are defined for all the parameter types we support. However, see our
 # [Kernel Guide
-# Notebook](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/) to
+# Notebook](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/) to
 # see how you can define your own bijectors and parameter types.
 
 # %%
@@ -156,7 +156,7 @@ transform(_close_to_zero_state, DEFAULT_BIJECTION, inverse=True)
 # may be nested within several functions e.g., a kernel function within a GP model.
 # Fortunately, transforming several parameters is a simple operation that we here
 # demonstrate for a conjugate GP posterior (see our [Regression
-# Notebook](https://docs.jaxgaussianprocesses.com/examples/regression/) for detailed
+# Notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/) for detailed
 # explanation of this model.).
 
 # %%
@@ -239,7 +239,7 @@ print(positive_reals)
 # useful as it allows us to efficiently operate on a subset of the parameters whilst
 # leaving the others untouched. Looking forward, we hope to use this functionality in
 # our [Variational Inference
-# Approximations](https://docs.jaxgaussianprocesses.com/examples/uncollapsed_vi/) to
+# Approximations](https://docs.jaxgaussianprocesses.com/_examples/uncollapsed_vi/) to
 # perform more efficient updates of the variational parameters and then the model's
 # hyperparameters.
 
@@ -361,7 +361,7 @@ ax.set(xlabel="x", ylabel="m(x)")
 # In this notebook we have explored how GPJax's Flax-based backend may be easily
 # manipulated and extended. For a more applied look at this, see how we construct a
 # kernel on polar coordinates in our [Kernel
-# Guide](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/#custom-kernel)
+# Guide](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/#custom-kernel)
 # notebook.
 #
 # ## System configuration

--- a/examples/barycentres.py
+++ b/examples/barycentres.py
@@ -154,9 +154,9 @@ plt.show()
 # We'll now independently learn Gaussian process posterior distributions for each
 # dataset. We won't spend any time here discussing how GP hyperparameters are
 # optimised. For advice on achieving this, see the
-# [Regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/)
+# [Regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/)
 # for advice on optimisation and the
-# [Kernels notebook](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/) for
+# [Kernels notebook](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/) for
 # advice on selecting an appropriate kernel.
 
 

--- a/examples/barycentres.py
+++ b/examples/barycentres.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/bayesian_optimisation.py
+++ b/examples/bayesian_optimisation.py
@@ -20,7 +20,7 @@
 #
 # In this guide we introduce the Bayesian Optimisation (BO) paradigm for
 # optimising black-box functions. We'll assume an understanding of Gaussian processes
-# (GPs), so if you're not familiar with them, check out our [GP introduction notebook](https://docs.jaxgaussianprocesses.com/examples/intro_to_gps/).
+# (GPs), so if you're not familiar with them, check out our [GP introduction notebook](https://docs.jaxgaussianprocesses.com/_examples/intro_to_gps/).
 
 # %%
 from typing import (
@@ -278,7 +278,7 @@ opt_posterior = return_optimised_posterior(D, prior, key)
 # will do this using the `sample_approx` method, which generates an approximate sample
 # from the posterior using decoupled sampling introduced in ([Wilson et al.,
 # 2020](https://proceedings.mlr.press/v119/wilson20a.html)) and discussed in our [Pathwise
-# Sampling Notebook](https://docs.jaxgaussianprocesses.com/examples/spatial/). This method
+# Sampling Notebook](https://docs.jaxgaussianprocesses.com/_examples/spatial/). This method
 # is used as it enables us to sample from the posterior in a manner which scales linearly
 # with the number of points sampled, $O(N)$, mitigating the cubic cost associated with
 # drawing exact samples from a GP posterior, $O(N^3)$. It also generates more accurate

--- a/examples/bayesian_optimisation.py
+++ b/examples/bayesian_optimisation.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/collapsed_vi.py
+++ b/examples/collapsed_vi.py
@@ -131,7 +131,7 @@ q = gpx.variational_families.CollapsedVariationalGaussian(
 # %% [markdown]
 # We now train our model akin to a Gaussian process regression model via the `fit`
 # abstraction. Unlike the regression example given in the
-# [conjugate regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/),
+# [conjugate regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/),
 # the inducing locations that induce our variational posterior distribution are now
 # part of the model's parameters. Using a gradient-based optimiser, we can then
 # _optimise_ their location such that the evidence lower bound is maximised.

--- a/examples/collapsed_vi.py
+++ b/examples/collapsed_vi.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax_beartype
 #     language: python

--- a/examples/constructing_new_kernels.py
+++ b/examples/constructing_new_kernels.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/constructing_new_kernels.py
+++ b/examples/constructing_new_kernels.py
@@ -71,7 +71,7 @@ cols = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 # * White noise
 # * Linear.
 # * Polynomial.
-# * [Graph kernels](https://docs.jaxgaussianprocesses.com/examples/graph_kernels/).
+# * [Graph kernels](https://docs.jaxgaussianprocesses.com/_examples/graph_kernels/).
 #
 # While the syntax is consistent, each kernel's type influences the
 # characteristics of the sample paths drawn. We visualise this below with 10
@@ -185,7 +185,7 @@ fig.colorbar(im3, ax=ax[3], fraction=0.05)
 # We'll demonstrate this process now for a circular kernel --- an adaption of
 # the excellent guide given in the PYMC3 documentation. We encourage curious
 # readers to visit their notebook
-# [here](https://www.pymc.io/projects/docs/en/v3/pymc-examples/examples/gaussian_processes/GP-Circular.html).
+# [here](https://www.pymc.io/projects/docs/en/v3/pymc-_examples/_examples/gaussian_processes/GP-Circular.html).
 #
 # ### Circular kernel
 #
@@ -272,7 +272,7 @@ class Polar(gpx.kernels.AbstractKernel):
 #
 # We proceed to fit a GP with our custom circular kernel to a random sequence of
 # points on a circle (see the
-# [Regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/)
+# [Regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/)
 # for further details on this process).
 
 # %%

--- a/examples/decision_making.py
+++ b/examples/decision_making.py
@@ -22,7 +22,7 @@
 # such problems include Bayesian optimisation (BO) and experimental design. For an
 # in-depth introduction to Bayesian optimisation itself, be sure to checkout out our
 # [Introduction to BO
-# Notebook](https://docs.jaxgaussianprocesses.com/examples/bayesian_optimisation/).
+# Notebook](https://docs.jaxgaussianprocesses.com/_examples/bayesian_optimisation/).
 #
 # We'll be using BO as a case study to demonstrate how one may use the decision making
 # module to solve sequential decision making problems. The goal of the decision making
@@ -76,7 +76,7 @@ cols = mpl.rcParams["axes.prop_cycle"].by_key()["color"]
 # ## The Black-Box Objective Function
 #
 # We'll be using the same problem as in the [Introduction to BO
-# Notebook](https://docs.jaxgaussianprocesses.com/examples/bayesian_optimisation/), but
+# Notebook](https://docs.jaxgaussianprocesses.com/_examples/bayesian_optimisation/), but
 # rather than focussing on the mechanics of BO we'll be looking at how one may use the
 # abstractions provided by the decision making module to implement the BO loop.
 #
@@ -181,7 +181,7 @@ likelihood_builder = lambda n: gpx.likelihoods.Gaussian(
 # this for us. This class takes as input a `prior` and `likeligood_builder`, which we have
 # defined above. We tend to also optimise the hyperparameters of the GP prior when
 # "fitting" our GP, as demonstrated in the [Regression
-# notebook](https://docs.jaxgaussianprocesses.com/examples/regression/). This will be
+# notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/). This will be
 # using the GPJax `fit` method under the hood, which requires an `optimization_objective`,
 # `optimizer` and `num_optimization_iters`. Therefore, we also pass these to the
 # `PosteriorHandler` as demonstrated below:
@@ -257,7 +257,7 @@ acquisition_maximizer = ContinuousSinglePointUtilityMaximizer(
 #
 # It is worth noting that `ThompsonSampling` is not the only utility function we could use,
 # since our module also provides e.g. `ProbabilityOfImprovement`, `ExpectedImprovment`,
-# which were briefly discussed in [our previous introduction to Bayesian optimisation](https://docs.jaxgaussianprocesses.com/examples/bayesian_optimisation/).
+# which were briefly discussed in [our previous introduction to Bayesian optimisation](https://docs.jaxgaussianprocesses.com/_examples/bayesian_optimisation/).
 
 
 # %% [markdown]

--- a/examples/decision_making.py
+++ b/examples/decision_making.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/deep_kernels.py
+++ b/examples/deep_kernels.py
@@ -141,7 +141,7 @@ class DeepKernelFunction(AbstractKernel):
 # activation functions between the layers. The first hidden layer contains 64 units,
 # while the second layer contains 32 units. Finally, we'll make the output of our
 # network a three units wide. The corresponding kernel that we define will then be of
-# [ARD form](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/#active-dimensions)
+# [ARD form](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/#active-dimensions)
 # to allow for different lengthscales in each dimension of the feature space.
 # Users may wish to design more intricate network structures for more complex tasks,
 # which functionality is supported well in Haiku.

--- a/examples/deep_kernels.py
+++ b/examples/deep_kernels.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/graph_kernels.py
+++ b/examples/graph_kernels.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/graph_kernels.py
+++ b/examples/graph_kernels.py
@@ -22,7 +22,7 @@
 # of a graph using a Gaussian process with a Matérn kernel presented in
 # <strong data-cite="borovitskiy2021matern"></strong>. For a general discussion of the
 # kernels supported within GPJax, see the
-# [kernels notebook](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels).
+# [kernels notebook](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels).
 
 # %%
 import random
@@ -153,7 +153,7 @@ cbar = plt.colorbar(sm, ax=ax)
 # non-Euclidean, our likelihood is still Gaussian and the model is still conjugate.
 # For this reason, we simply perform gradient descent on the GP's marginal
 # log-likelihood term as in the
-# [regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/).
+# [regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/).
 # We do this using the BFGS optimiser.
 
 # %%

--- a/examples/intro_to_gps.py
+++ b/examples/intro_to_gps.py
@@ -60,7 +60,7 @@
 # family, then there exists a conjugate prior. However, the conjugate prior may
 # not have a form that precisely reflects the practitioner's belief surrounding
 # the parameter. For this reason, conjugate models seldom appear; one exception
-# to this is GP regression that we present fully in our [Regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/).
+# to this is GP regression that we present fully in our [Regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/).
 #
 # For models that do not contain a conjugate prior, the marginal log-likelihood
 # must be calculated to normalise the posterior distribution and ensure it
@@ -475,7 +475,7 @@ with warnings.catch_warnings():
 # considers Gaussian likelihood functions where the role of $\phi$ is
 # superfluous. However, this intuition will be helpful for models with a
 # non-Gaussian likelihood, such as those encountered in
-# [classification](https://docs.jaxgaussianprocesses.com/examples/classification).
+# [classification](https://docs.jaxgaussianprocesses.com/_examples/classification).
 #
 # Applying Bayes' theorem \eqref{eq:BayesTheorem} yields the joint posterior distribution over the
 # latent function
@@ -492,7 +492,7 @@ with warnings.catch_warnings():
 # function with parameters $\boldsymbol{\theta}$ that maps pairs of inputs
 # $\mathbf{X}, \mathbf{X}' \in \mathcal{X}$ onto the real line. We dedicate the
 # entirety of the [Introduction to Kernels
-# notebook](https://docs.jaxgaussianprocesses.com/examples/intro_to_kernels) to
+# notebook](https://docs.jaxgaussianprocesses.com/_examples/intro_to_kernels) to
 # exploring the different GPs each kernel can yield.
 #
 # ## Gaussian process regression
@@ -560,7 +560,7 @@ with warnings.catch_warnings():
 # Bayes' theorem and the definition of a Gaussian random variable. Using the
 # ideas presented in this notebook, the user should be in a position to dive
 # into our [Regression
-# notebook](https://docs.jaxgaussianprocesses.com/examples/regression/) and
+# notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/) and
 # start getting their hands on some code. For those looking to learn more about
 # the underling theory of GPs, an excellent starting point is the [Gaussian
 # Processes for Machine Learning](http://gaussianprocess.org/gpml/) textbook.

--- a/examples/intro_to_gps.py
+++ b/examples/intro_to_gps.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/intro_to_kernels.py
+++ b/examples/intro_to_kernels.py
@@ -121,7 +121,7 @@ cols = mpl.rcParams["axes.prop_cycle"].by_key()["color"]
 # The second necessary condition is that the covariance function must be *positive
 # semi-definite* (PSD). In order to understand this condition, it is useful to first
 # introduce the concept of a *Gram matrix*. We'll use the same notation as the [GP introduction
-# notebook](https://docs.jaxgaussianprocesses.com/examples/intro_to_gps/), and denote
+# notebook](https://docs.jaxgaussianprocesses.com/_examples/intro_to_gps/), and denote
 # $n$ input points as $\mathbf{X} = \{\mathbf{x}_1, \ldots, \mathbf{x}_n\}$. Given these
 # input points and a kernel function $k$ the *Gram matrix* stores the pairwise kernel
 # evaluations between all input points. Mathematically, this leads to the Gram matrix being defined as:
@@ -230,7 +230,7 @@ for k, ax in zip(kernels, axes.ravel()):
 # gradient-based approach such as Adam or L-BFGS. Note that we may choose to fix some
 # hyperparameters, and in GPJax the parameter $\nu$ is set by the user, and not
 # inferred though optimisation. For more details on using the log marginal likelihood to
-# optimise kernel hyperparameters, see our [GP introduction notebook](https://docs.jaxgaussianprocesses.com/examples/intro_to_gps/#gaussian-process-regression).
+# optimise kernel hyperparameters, see our [GP introduction notebook](https://docs.jaxgaussianprocesses.com/_examples/intro_to_gps/#gaussian-process-regression).
 #
 # We'll demonstrate the advantages of being able to infer kernel parameters from the training data by fitting a GP to the widely used [Forrester function](https://www.sfu.ca/~ssurjano/forretal08.html):
 #
@@ -673,7 +673,7 @@ print(
 # %% [markdown]
 # ## Defining Kernels on Non-Euclidean Spaces
 #
-# In this notebook, we have focused solely on kernels whose domain resides in Euclidean space. However, what if one wished to work with data whose domain is non-Euclidean? For instance, one may wish to work with graph-structured data, or data which lies on a manifold, or even strings. Fortunately, kernels exist for a wide variety of domains. Whilst this is beyond the scope of this notebook, feel free to checkout out our [notebook on graph kernels](https://docs.jaxgaussianprocesses.com/examples/graph_kernels/) for an introduction on how to define the Matérn kernel on graph-structured data, and there are a wide variety of resources online for learning about defining kernels in other domains. In terms of open-source libraries, the [Geometric Kernels](https://github.com/GPflow/GeometricKernels) library could be a good place to start if you're interested in looking at how these kernels may be implemented, with the additional benefit that it is compatible with GPJax.
+# In this notebook, we have focused solely on kernels whose domain resides in Euclidean space. However, what if one wished to work with data whose domain is non-Euclidean? For instance, one may wish to work with graph-structured data, or data which lies on a manifold, or even strings. Fortunately, kernels exist for a wide variety of domains. Whilst this is beyond the scope of this notebook, feel free to checkout out our [notebook on graph kernels](https://docs.jaxgaussianprocesses.com/_examples/graph_kernels/) for an introduction on how to define the Matérn kernel on graph-structured data, and there are a wide variety of resources online for learning about defining kernels in other domains. In terms of open-source libraries, the [Geometric Kernels](https://github.com/GPflow/GeometricKernels) library could be a good place to start if you're interested in looking at how these kernels may be implemented, with the additional benefit that it is compatible with GPJax.
 
 # %% [markdown]
 # ## Further Reading
@@ -682,7 +682,7 @@ print(
 #
 # - [Gaussian Processes for Machine Learning](http://www.gaussianprocess.org/gpml/chapters/RW.pdf) - Chapter 4 provides a comprehensive overview of kernels, diving deep into some of the technical details and also providing some kernels defined on non-Euclidean spaces such as strings.
 # - David Duvenaud's [Kernel Cookbook](https://www.cs.toronto.edu/~duvenaud/cookbook/) is a great resource for learning about kernels, and also provides some information about some of the pitfalls people commonly encounter when using the Matérn family of kernels. His PhD thesis, [Automatic Model Construction with Gaussian Processes](https://www.cs.toronto.edu/~duvenaud/thesis.pdf), also provides some in-depth recipes for how one may incorporate their prior knowledge when constructing kernels.
-# - Finally, please check out our [more advanced kernel guide](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/), which details some more kernels available in GPJax as well as how one may combine kernels together to form more complex kernels.
+# - Finally, please check out our [more advanced kernel guide](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/), which details some more kernels available in GPJax as well as how one may combine kernels together to form more complex kernels.
 #
 # ## System Configuration
 

--- a/examples/intro_to_kernels.py
+++ b/examples/intro_to_kernels.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.2
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python
@@ -37,7 +37,10 @@ import pandas as pd
 from sklearn.preprocessing import StandardScaler
 
 from examples.utils import use_mpl_style
-from gpjax.parameters import PositiveReal, Static
+from gpjax.parameters import (
+    PositiveReal,
+    Static,
+)
 from gpjax.typing import Array
 
 config.update("jax_enable_x64", True)

--- a/examples/likelihoods_guide.py
+++ b/examples/likelihoods_guide.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/oceanmodelling.py
+++ b/examples/oceanmodelling.py
@@ -217,7 +217,7 @@ dataset_ground_truth = dataset_3d(pos_test, vel_test)
 #
 # where $k^{(z)}\left(\mathbf{x}, \mathbf{x}^{\prime}\right)$ are the user chosen kernels for each dimension. What this means is that there are no correlations between the $x^{(0)}$ and $x^{(1)}$ dimensions for all choices $\mathbf{X}$ and $\mathbf{X}^{\prime}$, since there are no off-diagonal elements in the Gram matrix populated by this choice.
 #
-# To implement this approach in GPJax, we define `VelocityKernel` in the following cell, following the steps outlined in the [custom kernels notebook](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels/#custom-kernel). This modular implementation takes the choice of user kernels as its class attributes: `kernel0` and `kernel1`. We must additionally pass the argument `active_dims = [0,1]`, which is an attribute of the base class `AbstractKernel`, into the chosen kernels. This is necessary such that the subsequent likelihood optimisation does not optimise over the artificial label dimension.
+# To implement this approach in GPJax, we define `VelocityKernel` in the following cell, following the steps outlined in the [custom kernels notebook](https://docs.jaxgaussianprocesses.com/_examples/constructing_new_kernels/#custom-kernel). This modular implementation takes the choice of user kernels as its class attributes: `kernel0` and `kernel1`. We must additionally pass the argument `active_dims = [0,1]`, which is an attribute of the base class `AbstractKernel`, into the chosen kernels. This is necessary such that the subsequent likelihood optimisation does not optimise over the artificial label dimension.
 #
 
 
@@ -272,7 +272,7 @@ velocity_posterior = initialise_gp(kernel, mean, dataset_train)
 
 
 # %% [markdown]
-# With a model now defined, we can proceed to optimise the hyperparameters of our likelihood over $D_0$. This is done by minimising the MLL using `BFGS`. We also plot its value at each step to visually confirm that we have found the minimum. See the  [introduction to Gaussian Processes](https://docs.jaxgaussianprocesses.com/examples/intro_to_gps/) notebook for more information on optimising the MLL.
+# With a model now defined, we can proceed to optimise the hyperparameters of our likelihood over $D_0$. This is done by minimising the MLL using `BFGS`. We also plot its value at each step to visually confirm that we have found the minimum. See the  [introduction to Gaussian Processes](https://docs.jaxgaussianprocesses.com/_examples/intro_to_gps/) notebook for more information on optimising the MLL.
 
 
 # %%

--- a/examples/oceanmodelling.py
+++ b/examples/oceanmodelling.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/poisson.py
+++ b/examples/poisson.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: base
 #     language: python

--- a/examples/regression.py
+++ b/examples/regression.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/uncollapsed_vi.py
+++ b/examples/uncollapsed_vi.py
@@ -25,7 +25,7 @@
 # non-conjugate Gaussian processes with more than ~5000 data points. However, for
 # conjugate models of less than 5000 data points, we recommend using the marginal
 # log-likelihood approach presented in the
-# [regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/).
+# [regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/).
 # Though we illustrate SVGPs here with a conjugate regression example, the same GPJax
 # code works for general likelihoods, such as a Bernoulli for classification.
 
@@ -267,7 +267,7 @@ opt_posterior, history = gpx.fit(
 # predictions at novel inputs akin
 # to all other models within GPJax on our variational process object $q(\cdot)$ (for
 # example, see the
-# [regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/)).
+# [regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/)).
 
 # %%
 latent_dist = opt_posterior(xtest)

--- a/examples/uncollapsed_vi.py
+++ b/examples/uncollapsed_vi.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.2
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax_beartype
 #     language: python

--- a/examples/yacht.py
+++ b/examples/yacht.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: gpjax
 #     language: python

--- a/examples/yacht.py
+++ b/examples/yacht.py
@@ -65,14 +65,14 @@ key = jr.key(42)
 # covariates and a single positive, real valued response variable. There are 308
 # observations in the dataset, so we can comfortably use a conjugate regression
 # Gaussian process here (for more more details, checkout the
-# [Regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/)).
+# [Regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/)).
 
 # %%
 try:
     yacht = pd.read_fwf("data/yacht_hydrodynamics.data", header=None).values[:-1, :]
 except FileNotFoundError:
     yacht = pd.read_fwf(
-        "docs/examples/data/yacht_hydrodynamics.data", header=None
+        "docs/_examples/data/yacht_hydrodynamics.data", header=None
     ).values[:-1, :]
 
 X = yacht[:, :-1]
@@ -149,9 +149,9 @@ scaled_Xte = x_scaler.transform(Xte)
 # With data now loaded and preprocessed, we'll proceed to defining a Gaussian process
 # model and optimising its parameters. This notebook purposefully does not go into
 # great detail on this process, so please see notebooks such as the
-# [Regression notebook](https://docs.jaxgaussianprocesses.com/examples/regression/)
+# [Regression notebook](https://docs.jaxgaussianprocesses.com/_examples/regression/)
 # and
-# [Classification notebook](https://docs.jaxgaussianprocesses.com/examples/classification)
+# [Classification notebook](https://docs.jaxgaussianprocesses.com/_examples/classification)
 # for further information.
 #
 # ### Model specification

--- a/gpjax/decision_making/test_functions/non_conjugate_functions.py
+++ b/gpjax/decision_making/test_functions/non_conjugate_functions.py
@@ -32,7 +32,7 @@ from gpjax.typing import (
 class PoissonTestFunction:
     """
     Test function for GPs utilising the Poisson likelihood. Function taken from
-    https://docs.jaxgaussianprocesses.com/examples/poisson/#dataset.
+    https://docs.jaxgaussianprocesses.com/_examples/poisson/#dataset.
 
     Attributes:
         search_space (ContinuousSearchSpace): Search space for the function.
@@ -77,7 +77,7 @@ class PoissonTestFunction:
     def evaluate(self, x: Float[Array, "N 1"]) -> Int[Array, "N 1"]:
         """
         Evaluate the test function at a set of points. Function taken from
-        https://docs.jaxgaussianprocesses.com/examples/poisson/#dataset.
+        https://docs.jaxgaussianprocesses.com/_examples/poisson/#dataset.
 
         Args:
             x (Float[Array, 'N D']): Points to evaluate the test function at.


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `hatch run dev:format` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

There are many broken links in the documentation referencing the examples. I have fixed them in this PR.
