### PR TITLE
Add JIT-safe assertions

### DIFF
--- a/docs/sharp_bits.md
+++ b/docs/sharp_bits.md
@@ -190,6 +190,7 @@ import jax
 import jax.numpy as jnp
 import gpjax as gpx
 
+x = jnp.linspace(0, 1, 10)[:, None]
 
 def compute_gram(lengthscale):
     k = gpx.kernels.RBF(active_dims=[0], lengthscale=lengthscale, variance=jnp.array(1.0))
@@ -202,7 +203,10 @@ so far so good. However, if we try to JIT compile this function, we will get an 
 
 ```python
 jit_compute_gram = jax.jit(compute_gram)
-jit_compute_gram(1.0)
+try:
+    jit_compute_gram(1.0)
+except Exception as e:
+    print(e)
 ```
 
 This error is due to the fact that the `RBF` kernel contains an assertion that checks

--- a/docs/sharp_bits.md
+++ b/docs/sharp_bits.md
@@ -175,3 +175,54 @@ mini-batch optimisation of the parameters of your sparse Gaussian process model.
 model will scale linearly in the batch size and quadratically in the number of inducing
 points. We demonstrate its use in
 [our sparse stochastic variational inference notebook](_examples/uncollapsed_vi.md).
+
+## JIT compilation
+
+There are a subset of operations in GPJax that are not JIT compatible by default. This
+is because we have assertions in place to check the properties of the parameters. For
+example, we check that the lengthscale parameter that a user provides is positive. This
+makes for a better user experience as we can provide more informative error messages;
+however, JIT compiling functions wherein these assertions are made will break the code.
+As an example, consider the following code:
+
+```python
+import jax
+import gpjax as gpx
+
+def compute_gram(lengthscale):
+    k = gpx.kernels.RBF(active_dims=[0], lengthscale=lengthscale, variance=jnp.array(1.0))
+    return k.gram(x)
+
+compute_gram(1.0)
+```
+
+so far so good. However, if we try to JIT compile this function, we will get an error:
+
+```python
+jit_compute_gram = jax.jit(compute_gram)
+jit_compute_gram(1.0)
+```
+
+This error is due to the fact that the `RBF` kernel contains an assertion that checks
+that the lengthscale is positive. It does not matter that the assertion is satisfied;
+the very presence of the assertion will break JIT compilation.
+
+To resolve this, we can use the `checkify` decorator to remove the assertion. This will
+allow the function to be JIT compiled.
+
+```python
+from jax.experimental import checkify
+
+jit_compute_gram = jax.jit(checkify.checkify(compute_gram))
+error, value = jit_compute_gram(1.0)
+```
+By virtue of the `checkify.checkify`, a tuple is returned where the first element is the
+output of the assertion, and the second element is the value of the function. 
+
+This design is not perfect, and in an ideal world we would not enforce the user to wrap
+their code in `checkify.checkify`. We are actively looking into cleaner ways to provide
+guardrails in a less intrusive manner. However, for now, should you try to JIT compile
+a component of GPJax wherein there is an assertion, you will need to wrap the function
+in `checkify.checkify` as shown above.
+
+For more on `checkify`, please see the [JAX Checkify Doc](https://docs.jax.dev/en/latest/debugging/checkify_guide.html).

--- a/docs/sharp_bits.md
+++ b/docs/sharp_bits.md
@@ -187,7 +187,9 @@ As an example, consider the following code:
 
 ```python
 import jax
+import jax.numpy as jnp
 import gpjax as gpx
+
 
 def compute_gram(lengthscale):
     k = gpx.kernels.RBF(active_dims=[0], lengthscale=lengthscale, variance=jnp.array(1.0))

--- a/gpjax/kernels/nonstationary/polynomial.py
+++ b/gpjax/kernels/nonstationary/polynomial.py
@@ -46,7 +46,7 @@ class Polynomial(AbstractKernel):
         self,
         active_dims: tp.Union[list[int], slice, None] = None,
         degree: int = 2,
-        shift: tp.Union[ScalarFloat, nnx.Variable[ScalarArray]] = 0.0,
+        shift: tp.Union[ScalarFloat, nnx.Variable[ScalarArray]] = 1.0,
         variance: tp.Union[ScalarFloat, nnx.Variable[ScalarArray]] = 1.0,
         n_dims: tp.Union[int, None] = None,
         compute_engine: AbstractKernelComputation = DenseKernelComputation(),

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -1,16 +1,11 @@
 import typing as tp
 
 from flax import nnx
+from jax.experimental import checkify
 import jax.numpy as jnp
-import jax
-import jax.lax as lax
 import jax.tree_util as jtu
 from jax.typing import ArrayLike
 import tensorflow_probability.substrates.jax.bijectors as tfb
-import chex
-import jax
-import jax.numpy as jnp
-from jax.experimental import checkify
 
 T = tp.TypeVar("T", bound=tp.Union[ArrayLike, list[float]])
 ParameterTag = str

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -12,7 +12,10 @@ from gpjax.parameters import (
     Real,
     SigmoidBounded,
     Static,
+    _check_in_bounds,
+    _check_is_lower_triangular,
     _check_is_positive,
+    _check_is_square,
     _safe_assert,
     transform,
 )
@@ -80,3 +83,31 @@ def test_check_is_positive():
 
     jitted_fn = jit(checkify.checkify(_dummy_fn))
     jitted_fn(jnp.array(3.0))
+
+
+def test_check_is_square():
+    # Check square matrix
+    _safe_assert(_check_is_square, jnp.full((2, 2), 1.0))
+    # Check non-square matrix
+    with pytest.raises(ValueError):
+        _safe_assert(_check_is_square, jnp.full((2, 3), 1.0))
+
+
+def test_check_is_lower_triangular():
+    # Check lower triangular matrix
+    _safe_assert(_check_is_lower_triangular, jnp.tril(jnp.eye(2)))
+    # Check non-lower triangular matrix
+    with pytest.raises(ValueError):
+        _safe_assert(_check_is_lower_triangular, jnp.linspace(0.0, 1.0, 4))
+
+
+def test_check_in_bounds():
+    # Check in bounds
+    _safe_assert(
+        _check_in_bounds, jnp.array(0.5), low=jnp.array(0.0), high=jnp.array(1.0)
+    )
+    # Check out of bounds
+    with pytest.raises(ValueError):
+        _safe_assert(
+            _check_in_bounds, jnp.array(1.5), low=jnp.array(0.0), high=jnp.array(1.0)
+        )

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,9 +1,8 @@
 from flax import nnx
+from jax import jit
+from jax.experimental import checkify
 import jax.numpy as jnp
 import pytest
-from jax import jit
-
-from gpjax.kernels import RBF
 
 from gpjax.parameters import (
     DEFAULT_BIJECTION,
@@ -13,11 +12,10 @@ from gpjax.parameters import (
     Real,
     SigmoidBounded,
     Static,
-    transform,
     _check_is_positive,
     _safe_assert,
+    transform,
 )
-from jax.experimental import checkify
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `hatch run dev:format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

This PR replaces regular assertions with ones from JAX's checkify module. This allows for assertions to be done in a manner which is still JIT-compilable.

Issue Number: #495 
