### PR TITLE
Introduce NonNegativeReal parameters

### DIFF
--- a/examples/constructing_new_kernels.py
+++ b/examples/constructing_new_kernels.py
@@ -33,7 +33,6 @@ from jaxtyping import (
     install_import_hook,
 )
 import matplotlib.pyplot as plt
-import numpyro.distributions as npd
 from numpyro.distributions import constraints
 import numpyro.distributions.transforms as npt
 
@@ -51,8 +50,6 @@ config.update("jax_enable_x64", True)
 with install_import_hook("gpjax", "beartype.beartype"):
     import gpjax as gpx
 
-
-tfb = tfp.bijectors
 
 # set the default style for plotting
 use_mpl_style()

--- a/gpjax/kernels/nonstationary/arccosine.py
+++ b/gpjax/kernels/nonstationary/arccosine.py
@@ -23,7 +23,10 @@ from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
 )
-from gpjax.parameters import PositiveReal
+from gpjax.parameters import (
+    NonNegativeReal,
+    PositiveReal,
+)
 from gpjax.typing import (
     Array,
     ScalarArray,
@@ -91,9 +94,9 @@ class ArcCosine(AbstractKernel):
         if isinstance(variance, nnx.Variable):
             self.variance = variance
         else:
-            self.variance = PositiveReal(variance)
+            self.variance = NonNegativeReal(variance)
             if tp.TYPE_CHECKING:
-                self.variance = tp.cast(PositiveReal[ScalarArray], self.variance)
+                self.variance = tp.cast(NonNegativeReal[ScalarArray], self.variance)
 
         if isinstance(bias_variance, nnx.Variable):
             self.bias_variance = bias_variance

--- a/gpjax/kernels/nonstationary/linear.py
+++ b/gpjax/kernels/nonstationary/linear.py
@@ -23,7 +23,7 @@ from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
 )
-from gpjax.parameters import PositiveReal
+from gpjax.parameters import NonNegativeReal
 from gpjax.typing import (
     Array,
     ScalarArray,
@@ -64,9 +64,9 @@ class Linear(AbstractKernel):
         if isinstance(variance, nnx.Variable):
             self.variance = variance
         else:
-            self.variance = PositiveReal(variance)
+            self.variance = NonNegativeReal(variance)
             if tp.TYPE_CHECKING:
-                self.variance = tp.cast(PositiveReal[ScalarArray], self.variance)
+                self.variance = tp.cast(NonNegativeReal[ScalarArray], self.variance)
 
     def __call__(
         self,

--- a/gpjax/kernels/nonstationary/polynomial.py
+++ b/gpjax/kernels/nonstationary/polynomial.py
@@ -23,7 +23,10 @@ from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
 )
-from gpjax.parameters import PositiveReal
+from gpjax.parameters import (
+    NonNegativeReal,
+    PositiveReal,
+)
 from gpjax.typing import (
     Array,
     ScalarArray,
@@ -76,9 +79,9 @@ class Polynomial(AbstractKernel):
         if isinstance(variance, nnx.Variable):
             self.variance = variance
         else:
-            self.variance = PositiveReal(variance)
+            self.variance = NonNegativeReal(variance)
             if tp.TYPE_CHECKING:
-                self.variance = tp.cast(PositiveReal[ScalarArray], self.variance)
+                self.variance = tp.cast(NonNegativeReal[ScalarArray], self.variance)
 
         self.name = f"Polynomial (degree {self.degree})"
 

--- a/gpjax/kernels/stationary/base.py
+++ b/gpjax/kernels/stationary/base.py
@@ -25,7 +25,10 @@ from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
 )
-from gpjax.parameters import PositiveReal
+from gpjax.parameters import (
+    NonNegativeReal,
+    PositiveReal,
+)
 from gpjax.typing import (
     Array,
     ScalarArray,
@@ -85,11 +88,11 @@ class StationaryKernel(AbstractKernel):
         if isinstance(variance, nnx.Variable):
             self.variance = variance
         else:
-            self.variance = PositiveReal(variance)
+            self.variance = NonNegativeReal(variance)
 
             # static typing
             if tp.TYPE_CHECKING:
-                self.variance = tp.cast(PositiveReal[ScalarFloat], self.variance)
+                self.variance = tp.cast(NonNegativeReal[ScalarFloat], self.variance)
 
     @property
     def spectral_density(self) -> npd.Normal | npd.StudentT:

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -28,7 +28,7 @@ from gpjax.integrators import (
     GHQuadratureIntegrator,
 )
 from gpjax.parameters import (
-    PositiveReal,
+    NonNegativeReal,
     Static,
 )
 from gpjax.typing import (
@@ -134,7 +134,7 @@ class Gaussian(AbstractLikelihood):
         self,
         num_datapoints: int,
         obs_stddev: tp.Union[
-            ScalarFloat, Float[Array, "#N"], PositiveReal, Static
+            ScalarFloat, Float[Array, "#N"], NonNegativeReal, Static
         ] = 1.0,
         integrator: AbstractIntegrator = AnalyticalGaussianIntegrator(),
     ):
@@ -148,8 +148,8 @@ class Gaussian(AbstractLikelihood):
                 likelihoods. Must be an instance of `AbstractIntegrator`. For the Gaussian likelihood, this defaults to
                 the `AnalyticalGaussianIntegrator`, as the expected log likelihood can be computed analytically.
         """
-        if not isinstance(obs_stddev, (PositiveReal, Static)):
-            obs_stddev = PositiveReal(jnp.asarray(obs_stddev))
+        if not isinstance(obs_stddev, (NonNegativeReal, Static)):
+            obs_stddev = NonNegativeReal(jnp.asarray(obs_stddev))
         self.obs_stddev = obs_stddev
 
         super().__init__(num_datapoints, integrator)

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -82,6 +82,14 @@ class Parameter(nnx.Variable[T]):
         self._tag = tag
 
 
+class NonNegativeReal(Parameter[T]):
+    """Parameter that is non-negative."""
+
+    def __init__(self, value: T, tag: ParameterTag = "non_negative", **kwargs):
+        super().__init__(value=value, tag=tag, **kwargs)
+        _safe_assert(_check_is_non_negative, self.value)
+
+
 class PositiveReal(Parameter[T]):
     """Parameter that is strictly positive."""
 
@@ -143,6 +151,7 @@ class LowerTriangular(Parameter[T]):
 
 DEFAULT_BIJECTION = {
     "positive": npt.SoftplusTransform(),
+    "non_negative": npt.SoftplusTransform(),
     "real": npt.IdentityTransform(),
     "sigmoid": npt.SigmoidTransform(),
     "lower_triangular": FillTriangularTransform(),
@@ -162,6 +171,13 @@ def _check_is_arraylike(value: T) -> None:
         raise TypeError(
             f"Expected parameter value to be an array-like type. Got {value}."
         )
+
+
+@checkify.checkify
+def _check_is_non_negative(value):
+    checkify.check(
+        jnp.all(value >= 0), "value needs to be non-negative, got {value}", value=value
+    )
 
 
 @checkify.checkify

--- a/tests/test_kernels/test_nonstationary.py
+++ b/tests/test_kernels/test_nonstationary.py
@@ -31,7 +31,7 @@ from gpjax.kernels.nonstationary import (
     Polynomial,
 )
 from gpjax.parameters import (
-    PositiveReal,
+    NonNegativeReal,
     Static,
 )
 
@@ -96,8 +96,8 @@ def test_init_override_paramtype(kernel_request):
             continue
         new_params[param] = Static(value)
 
-    k = kernel(**new_params, variance=PositiveReal(variance))
-    assert isinstance(k.variance, PositiveReal)
+    k = kernel(**new_params, variance=NonNegativeReal(variance))
+    assert isinstance(k.variance, NonNegativeReal)
 
     for param in params.keys():
         if param in ("degree", "order"):
@@ -112,7 +112,7 @@ def test_init_defaults(kernel: type[AbstractKernel]):
 
     # Check that the parameters are set correctly
     assert isinstance(k.compute_engine, type(AbstractKernelComputation()))
-    assert isinstance(k.variance, PositiveReal)
+    assert isinstance(k.variance, NonNegativeReal)
 
 
 @pytest.mark.parametrize("kernel", [k[0] for k in TESTED_KERNELS])
@@ -122,7 +122,7 @@ def test_init_variances(kernel: type[AbstractKernel], variance):
     k = kernel(variance=variance)
 
     # Check that the parameters are set correctly
-    assert isinstance(k.variance, PositiveReal)
+    assert isinstance(k.variance, NonNegativeReal)
     assert jnp.allclose(k.variance.value, jnp.asarray(variance))
 
     # Check that error is raised if variance is not valid

--- a/tests/test_kernels/test_stationary.py
+++ b/tests/test_kernels/test_stationary.py
@@ -35,6 +35,7 @@ from gpjax.kernels.stationary import (
 )
 from gpjax.kernels.stationary.base import StationaryKernel
 from gpjax.parameters import (
+    NonNegativeReal,
     PositiveReal,
     Static,
 )
@@ -106,12 +107,12 @@ def test_init_override_paramtype(kernel_request):
     for param, value in params.items():
         new_params[param] = Static(value)
 
-    kwargs = {**new_params, "variance": PositiveReal(variance)}
+    kwargs = {**new_params, "variance": NonNegativeReal(variance)}
     if kernel != White:
         kwargs["lengthscale"] = PositiveReal(lengthscale)
 
     k = kernel(**kwargs)
-    assert isinstance(k.variance, PositiveReal)
+    assert isinstance(k.variance, NonNegativeReal)
 
     for param in params.keys():
         assert isinstance(getattr(k, param), Static)
@@ -124,7 +125,7 @@ def test_init_defaults(kernel: type[StationaryKernel]):
 
     # Check that the parameters are set correctly
     assert isinstance(k.compute_engine, type(AbstractKernelComputation()))
-    assert isinstance(k.variance, PositiveReal)
+    assert isinstance(k.variance, NonNegativeReal)
     assert isinstance(k.lengthscale, PositiveReal)
 
 
@@ -167,7 +168,7 @@ def test_init_variances(kernel: type[StationaryKernel], variance):
     k = kernel(variance=variance)
 
     # Check that the parameters are set correctly
-    assert isinstance(k.variance, PositiveReal)
+    assert isinstance(k.variance, NonNegativeReal)
     assert jnp.allclose(k.variance.value, jnp.asarray(variance))
 
     # Check that error is raised if variance is not valid

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -52,8 +52,8 @@ def _compute_latent_dist(
     return latent_dist, latent_mean, latent_cov
 
 
-@pytest.mark.parametrize("n", [1, 2, 10])
-@pytest.mark.parametrize("obs_stddev", [0.1, 0.5, 1.0])
+@pytest.mark.parametrize("n", [1, 2, 10, 3])
+@pytest.mark.parametrize("obs_stddev", [0.1, 0.5, 1.0, 0.0])
 def test_gaussian_likelihood(n: int, obs_stddev: float):
     x = jnp.linspace(-3.0, 3.0).reshape(-1, 1)
     likelihood = Gaussian(num_datapoints=n, obs_stddev=obs_stddev)

--- a/tests/test_numpyro_extras.py
+++ b/tests/test_numpyro_extras.py
@@ -193,7 +193,7 @@ def test_inverse_non_square_error():
         # Extract dimensions
         dim1, dim2 = matrix.shape[-2:]
         # Use a simpler regex pattern that doesn't include parentheses
-        error_pattern = f"Input matrix must be square; got shape"
+        error_pattern = "Input matrix must be square; got shape"
         with pytest.raises(ValueError, match=error_pattern):
             ft.inv(matrix)
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -7,6 +7,7 @@ import pytest
 from gpjax.parameters import (
     DEFAULT_BIJECTION,
     LowerTriangular,
+    NonNegativeReal,
     Parameter,
     PositiveReal,
     Real,
@@ -24,6 +25,8 @@ from gpjax.parameters import (
 @pytest.mark.parametrize(
     "param, value",
     [
+        (NonNegativeReal, 0.0),
+        (NonNegativeReal, 1.0),
         (PositiveReal, 1.0),
         (Real, 2.0),
         (SigmoidBounded, 0.5),
@@ -48,6 +51,7 @@ def test_transform(param, value):
 @pytest.mark.parametrize(
     "param, tag",
     [
+        (NonNegativeReal(0.0), "non_negative"),
         (PositiveReal(1.0), "positive"),
         (Real(2.0), "real"),
         (SigmoidBounded(0.5), "sigmoid"),


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `hatch run dev:format` before committing.
- [x] I've added tests for new code.
- [ ] ~~I've added docstrings for the new code.~~ N/A

## Description

Introduced a new NonNegativeReal parameter type. This has two primary applications.

### Kernel variance parameter

This has been implemented into kernel variance parameters. This allows kernels to be 'turned off' as required by setting `variance=gpx.parameter.Static(0.0)`. This is potentially useful for kernel searching algorithms. 

I have been using this feature as an optional add-on kernel which defaults to 'off'.

### Gaussian likelihood `obs_stddev`

By allowing `gpx.likelihoods.Gaussian()` to accept `obs_stddev=0.0` we can 'turn off' the likelihood. This is important for GP emulators of computer models. The easiest way to see this working well is by removing the observation noise from the regression example on the documentation.

There is perhaps a cleaner solution by defining a new likelihood class, `emulator` say, with no `obs_stddev` argument which simply returns the required number of zeros when called.

#### Why is this needed at all?

One could argue that this is not necessary as using `gps.Prior()` should be sufficient for building emulators. From a development point of view, it is easier to build tools that rely purely on the `AbstractPosterior` class with a likelihood of fixed structure baked in rather than also having to account for the `Prior` class thus rendering a likelihood 'optional'. Hence a quick 'hack' such as my implementation, or potentially an arguably cleaner `emulator` likelihood is easier to account for.

Issue Number: N/A
