### PR TITLE
Add `fit_lbfgs` using Optax

### DIFF
--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -32,6 +32,7 @@ from gpjax.citation import cite
 from gpjax.dataset import Dataset
 from gpjax.fit import (
     fit,
+    fit_lbfgs,
     fit_scipy,
 )
 
@@ -56,5 +57,6 @@ __all__ = [
     "fit",
     "Module",
     "param_field",
+    "fit_lbfgs",
     "fit_scipy",
 ]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -172,15 +172,12 @@ def test_fit_lbfgs_simple():
         return jnp.mean((pred - data.y) ** 2)
 
     # Train with bfgs!
-    trained_model, hist = fit_lbfgs(
+    trained_model, final_loss = fit_lbfgs(
         model=model,
         objective=mse,
         train_data=D,
         max_iters=10,
     )
-
-    # Ensure we return a history of the correct length
-    assert len(hist) > 2
 
     # Ensure we return a model of the same class
     assert isinstance(trained_model, LinearModel)
@@ -245,7 +242,7 @@ def test_fit_lbfgs_gp_regression(n_data: int) -> None:
     posterior = prior * likelihood
 
     # Train with BFGS!
-    trained_model_bfgs, history_bfgs = fit_lbfgs(
+    trained_model_bfgs, final_loss = fit_lbfgs(
         model=posterior,
         objective=conjugate_mll,
         train_data=D,
@@ -254,9 +251,6 @@ def test_fit_lbfgs_gp_regression(n_data: int) -> None:
 
     # Ensure the trained model is a Gaussian process posterior
     assert isinstance(trained_model_bfgs, ConjugatePosterior)
-
-    # Ensure we return a history_bfgs of the correct length
-    assert len(history_bfgs) > 2
 
     # Ensure we reduce the loss
     assert conjugate_mll(trained_model_bfgs, D) < conjugate_mll(posterior, D)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -13,18 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 
-from beartype.typing import Any
-from flax import nnx
 import jax.numpy as jnp
 import jax.random as jr
-from jaxtyping import (
-    Float,
-    Num,
-)
 import optax as ox
 import pytest
 import scipy
-
+from beartype.typing import Any
+from flax import nnx
 from gpjax.dataset import Dataset
 from gpjax.fit import (
     _check_batch_size,
@@ -35,6 +30,7 @@ from gpjax.fit import (
     _check_train_data,
     _check_verbose,
     fit,
+    fit_lbfgs,
     fit_scipy,
     get_batch,
 )
@@ -58,6 +54,10 @@ from gpjax.parameters import (
 )
 from gpjax.typing import Array
 from gpjax.variational_families import VariationalGaussian
+from jaxtyping import (
+    Float,
+    Num,
+)
 
 
 def test_fit_simple() -> None:
@@ -149,6 +149,49 @@ def test_fit_scipy_simple():
     assert trained_model.bias.value == 1.0
 
 
+def test_fit_lbfgs_simple():
+    # Create dataset:
+    X = jnp.linspace(0.0, 10.0, 100).reshape(-1, 1)
+    y = 2.0 * X + 1.0 + 10 * jr.normal(jr.PRNGKey(0), X.shape).reshape(-1, 1)
+    D = Dataset(X, y)
+
+    # Define linear model:
+    class LinearModel(nnx.Module):
+        def __init__(self, weight: float, bias: float):
+            self.weight = PositiveReal(weight)
+            self.bias = Static(bias)
+
+        def __call__(self, x):
+            return self.weight.value * x + self.bias.value
+
+    model = LinearModel(weight=1.0, bias=1.0)
+
+    # Define loss function:
+    def mse(model, data):
+        pred = model(data.X)
+        return jnp.mean((pred - data.y) ** 2)
+
+    # Train with bfgs!
+    trained_model, hist = fit_lbfgs(
+        model=model,
+        objective=mse,
+        train_data=D,
+        num_iters=10,
+    )
+
+    # Ensure we return a history of the correct length
+    assert len(hist) > 2
+
+    # Ensure we return a model of the same class
+    assert isinstance(trained_model, LinearModel)
+
+    # Test reduction in loss:
+    assert mse(trained_model, D) < mse(model, D)
+
+    # Test stop_gradient on bias:
+    assert trained_model.bias.value == 1.0
+
+
 @pytest.mark.parametrize("n_data", [20])
 @pytest.mark.parametrize("verbose", [True, False])
 def test_fit_gp_regression(n_data: int, verbose: bool) -> None:
@@ -187,8 +230,7 @@ def test_fit_gp_regression(n_data: int, verbose: bool) -> None:
 
 
 @pytest.mark.parametrize("n_data", [20])
-@pytest.mark.parametrize("verbose", [True, False])
-def test_fit_scipy_gp_regression(n_data: int, verbose: bool) -> None:
+def test_fit_lbfgs_gp_regression(n_data: int) -> None:
     # Create dataset:
     key = jr.PRNGKey(123)
     x = jnp.sort(
@@ -203,12 +245,11 @@ def test_fit_scipy_gp_regression(n_data: int, verbose: bool) -> None:
     posterior = prior * likelihood
 
     # Train with BFGS!
-    trained_model_bfgs, history_bfgs = fit_scipy(
+    trained_model_bfgs, history_bfgs = fit_lbfgs(
         model=posterior,
         objective=conjugate_mll,
         train_data=D,
-        max_iters=40,
-        verbose=verbose,
+        num_iters=40,
     )
 
     # Ensure the trained model is a Gaussian process posterior

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -176,7 +176,7 @@ def test_fit_lbfgs_simple():
         model=model,
         objective=mse,
         train_data=D,
-        num_iters=10,
+        max_iters=10,
     )
 
     # Ensure we return a history of the correct length
@@ -249,7 +249,7 @@ def test_fit_lbfgs_gp_regression(n_data: int) -> None:
         model=posterior,
         objective=conjugate_mll,
         train_data=D,
-        num_iters=40,
+        max_iters=40,
     )
 
     # Ensure the trained model is a Gaussian process posterior

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -19,16 +19,10 @@ from jax import config
 config.update("jax_enable_x64", True)
 
 
+import gpjax as gpx
 import jax.numpy as jnp
 import jax.random as jr
-from jaxtyping import (
-    Array,
-    Float,
-    Num,
-)
 import pytest
-
-import gpjax as gpx
 from gpjax.mean_functions import (
     AbstractMeanFunction,
     CombinationMeanFunction,
@@ -36,6 +30,11 @@ from gpjax.mean_functions import (
     Zero,
 )
 from gpjax.parameters import Static
+from jaxtyping import (
+    Array,
+    Float,
+    Num,
+)
 
 
 def test_abstract() -> None:

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -19,10 +19,16 @@ from jax import config
 config.update("jax_enable_x64", True)
 
 
-import gpjax as gpx
 import jax.numpy as jnp
 import jax.random as jr
+from jaxtyping import (
+    Array,
+    Float,
+    Num,
+)
 import pytest
+
+import gpjax as gpx
 from gpjax.mean_functions import (
     AbstractMeanFunction,
     CombinationMeanFunction,
@@ -30,11 +36,6 @@ from gpjax.mean_functions import (
     Zero,
 )
 from gpjax.parameters import Static
-from jaxtyping import (
-    Array,
-    Float,
-    Num,
-)
 
 
 def test_abstract() -> None:


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `hatch run dev:format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

L-BFGS tends to be the most commonly used optimizer for fitting GPs (used, for example, in GPytorch/Botorch).

`gpx.fit_scipy` under the hood used `scipy.optimize.minimize`, which defaults to running L-BFGS (note, not `jax.scipy` but the original scipy, as `jax.scipy` only has BFGS rather than the reduced memory L-BFGS).
Optax has an [LBFGS implementation](https://optax.readthedocs.io/en/stable/_collections/examples/lbfgs.html#l-bfgs-as-a-solver), but **the API requires some additional arguments, namely `value`, `grad`, and `value_fn` in the `optim.update` step, that means that it can't be directly with `gpx.fit`**. Hence, in this PR I've added a new function, `fit_lbfgs`, that's a hybrid between the `fit_scipy` and `fit` functions, using Optax's LBFGS solver in a lax.while loop.

## Notes

- There are still potential use cases where `fit_scipy` might be preferable. For example, on a CPU-only system with a small number of datapoints, `fit_scipy` is in fact faster than `fit_lbfgs`, as the compilation time of the lax loop is nontrivial. However, **for larger numbers of datapoints or iterations, `fit_lbfgs` is faster, even on CPU.** 
- I chose to use a `lax.while` rather than a `lax.scan` because it allows early termination. I deemed this to be more important than logging the full history of the objective values. It also more closely reflects the `fit_scipy` interface.

Happy to be corrected on any of the above! Let me know what you think.
